### PR TITLE
replaced most "cat()" and "print()" invocations with "message()"…

### DIFF
--- a/R/MEDIPS.CpGenrich.R
+++ b/R/MEDIPS.CpGenrich.R
@@ -14,70 +14,70 @@ MEDIPS.CpGenrich <-function(file=NULL, BSgenome=NULL, extend=0, shift=0, uniq=1e
 
 	## Proof correctness....
 	if(is.null(BSgenome)){stop("Must specify a BSgenome library.")}
-	
-	## Read region file		
-	fileName=unlist(strsplit(file, "/"))[length(unlist(strsplit(file, "/")))]
-	path=paste(unlist(strsplit(file, "/"))[1:(length(unlist(strsplit(file, "/"))))-1], collapse="/") 
-	if(path==""){path=getwd()}		
-	if(!fileName%in%dir(path)){stop(paste("File", fileName, " not found in", path, sep =" "))}	
 
-	dataset = get(ls(paste("package:", BSgenome, sep = "")))	
+	## Read region file
+	fileName=unlist(strsplit(file, "/"))[length(unlist(strsplit(file, "/")))]
+	path=paste(unlist(strsplit(file, "/"))[1:(length(unlist(strsplit(file, "/"))))-1], collapse="/")
+	if(path==""){path=getwd()}
+	if(!fileName%in%dir(path)){stop(paste("File", fileName, " not found in", path, sep =" "))}
+
+	dataset = get(ls(paste("package:", BSgenome, sep = "")))
 
 	if(!paired){GRange.Reads = getGRange(fileName, path, extend, shift, chr.select, dataset, uniq)}
 	else{GRange.Reads = getPairedGRange(fileName, path, extend, shift, chr.select, dataset, uniq)}
-	
+
 	## Sort chromosomes
 	if(length(unique(seqlevels(GRange.Reads)))>1){chromosomes=mixedsort(unique(seqlevels(GRange.Reads)))}
 	if(length(unique(seqlevels(GRange.Reads)))==1){chromosomes=unique(seqlevels(GRange.Reads))}
-	
+
 	## Get chromosome lengths for all chromosomes within data set.
-	cat(paste("Loading chromosome lengths for ",BSgenome, "...\n", sep=""))		
+	message(paste("Loading chromosome lengths for ",BSgenome, "...\n", sep=""))
 
 	chr_lengths=as.numeric(seqlengths(dataset)[chromosomes])
 
 	ranges(GRange.Reads) <- restrict(ranges(GRange.Reads),+1)
-	
+
 	##Calculate CpG density for regions
 	total=length(chromosomes)
-	cat("Calculating CpG density for given regions...\n")  
-	seq=matrix(unlist(IRanges::lapply(RangedData(GRange.Reads),function(x){		
+	message("Calculating CpG density for given regions...\n")
+	seq=matrix(unlist(IRanges::lapply(RangedData(GRange.Reads),function(x){
 		i=which(mixedsort(chromosomes)%in%names(x) )
 		ranges(x)<-restrict(ranges(x),end=chr_lengths[which(chromosomes %in% names(x))])
 		y=DNAStringSet(getSeq(dataset, names=space(x), start=start(x), end=end(x), as.character=TRUE))
 		c(sum(as.numeric(vcountPattern("CG",y))),sum(as.numeric(vcountPattern("C",y))),sum(as.numeric(vcountPattern("G",y))),sum(as.numeric(width(y))),length(y))
 		}
 	),use.names=F),ncol=5,nrow=total,byrow=T)
-  
+
 	Value=colSums(seq)
 	unused=length(GRange.Reads)-Value[5]
-	if ( unused!=0 )cat(unused,"unused sequences, limits out of range\n")
-	
+	if (unused!=0) warning(unused,"unused sequences, limits out of range\n")
+
 	regions.CG=Value[1]
 	regions.C=Value[2]
 	regions.G=Value[3]
 	all.genomic=Value[4]
-	
+
 	regions.relH=as.numeric(regions.CG)/as.numeric(all.genomic)*100
-	regions.GoGe=(as.numeric(regions.CG)*as.numeric(all.genomic))/(as.numeric(regions.C)*as.numeric(regions.G))  
-	
+	regions.GoGe=(as.numeric(regions.CG)*as.numeric(all.genomic))/(as.numeric(regions.C)*as.numeric(regions.G))
+
 	##Calculate CpG density for reference genome
-	cat(paste("Calculating CpG density for the reference genome", BSgenome, "...\n", sep = " "))	
+	message(paste("Calculating CpG density for the reference genome", BSgenome, "...\n", sep = " "))
 	CG <- DNAStringSet("CG")
 	pdict0 <- PDict(CG)
 	params <- new("BSParams", X = dataset, FUN = countPDict, simplify = TRUE, exclude = c("rand", "chrUn"))
-	genome.CG=sum(bsapply(params, pdict = pdict0))			
+	genome.CG=sum(bsapply(params, pdict = pdict0))
 	params <- new("BSParams", X = dataset, FUN = alphabetFrequency, exclude = c("rand", "chrUn"), simplify=TRUE)
 	alphabet=bsapply(params)
 	genome.l=sum(as.numeric(alphabet))
- 	
+
 	genome.C=as.numeric(sum(alphabet[2,]))
 	genome.G=as.numeric(sum(alphabet[3,]))
 	genome.relH=genome.CG/genome.l*100
 	genome.GoGe=(genome.CG*genome.l)/(genome.C*genome.G);
-	
-	enrichment.score.relH=regions.relH/genome.relH	
-	enrichment.score.GoGe=regions.GoGe/genome.GoGe	
- 	
+
+	enrichment.score.relH=regions.relH/genome.relH
+	enrichment.score.GoGe=regions.GoGe/genome.GoGe
+
 	gc()
 	return(list(genome=BSgenome, regions.CG=regions.CG, regions.C=regions.C, regions.G=regions.G, regions.relH=regions.relH, regions.GoGe=regions.GoGe, genome.C=genome.C, genome.G=genome.G, genome.CG=genome.CG, genome.relH=genome.relH, genome.GoGe=genome.GoGe, enrichment.score.relH=enrichment.score.relH, enrichment.score.GoGe=enrichment.score.GoGe))
 }

--- a/R/MEDIPS.CpGenrich.R
+++ b/R/MEDIPS.CpGenrich.R
@@ -31,7 +31,7 @@ MEDIPS.CpGenrich <-function(file=NULL, BSgenome=NULL, extend=0, shift=0, uniq=1e
 	if(length(unique(seqlevels(GRange.Reads)))==1){chromosomes=unique(seqlevels(GRange.Reads))}
 
 	## Get chromosome lengths for all chromosomes within data set.
-	message(paste("Loading chromosome lengths for ",BSgenome, "...\n", sep=""))
+	message("Loading chromosome lengths for ", BSgenome, "...", appendLF=T)
 
 	chr_lengths=as.numeric(seqlengths(dataset)[chromosomes])
 
@@ -39,7 +39,7 @@ MEDIPS.CpGenrich <-function(file=NULL, BSgenome=NULL, extend=0, shift=0, uniq=1e
 
 	##Calculate CpG density for regions
 	total=length(chromosomes)
-	message("Calculating CpG density for given regions...\n")
+	message("Calculating CpG density for given regions...", appendLF=T)
 	seq=matrix(unlist(IRanges::lapply(RangedData(GRange.Reads),function(x){
 		i=which(mixedsort(chromosomes)%in%names(x) )
 		ranges(x)<-restrict(ranges(x),end=chr_lengths[which(chromosomes %in% names(x))])
@@ -61,7 +61,7 @@ MEDIPS.CpGenrich <-function(file=NULL, BSgenome=NULL, extend=0, shift=0, uniq=1e
 	regions.GoGe=(as.numeric(regions.CG)*as.numeric(all.genomic))/(as.numeric(regions.C)*as.numeric(regions.G))
 
 	##Calculate CpG density for reference genome
-	message(paste("Calculating CpG density for the reference genome", BSgenome, "...\n", sep = " "))
+	message("Calculating CpG density for the reference genome", BSgenome, "...", appendLF=T)
 	CG <- DNAStringSet("CG")
 	pdict0 <- PDict(CG)
 	params <- new("BSParams", X = dataset, FUN = countPDict, simplify = TRUE, exclude = c("rand", "chrUn"))

--- a/R/MEDIPS.GenomicCoordinates.R
+++ b/R/MEDIPS.GenomicCoordinates.R
@@ -9,15 +9,15 @@
 ##Author:	Lukas Chavez
 
 MEDIPS.GenomicCoordinates <- function(supersize_chr=NULL, no_chr_windows=NULL, chromosomes=NULL, chr_lengths=NULL, window_size=NULL){
-	
-	cat("Calculating genomic coordinates...")
-	
+
+	message("Calculating genomic coordinates...")
+
 	genomeVec_chr=vector(length=supersize_chr[length(chromosomes)], mode="character")
-	genomeVec_pos=vector(length=supersize_chr[length(chromosomes)], mode="numeric")		
-	
+	genomeVec_pos=vector(length=supersize_chr[length(chromosomes)], mode="numeric")
+
 	total=length(chromosomes)
- 	for(i in 1:length(chromosomes)){		
-		if(i==1){			
+ 	for(i in 1:length(chromosomes)){
+		if(i==1){
 			genomeVec_chr[1:no_chr_windows[i]]=chromosomes[i]
 			genomeVec_pos[1:no_chr_windows[i]]=seq(1, chr_lengths[i], window_size)
 		}
@@ -26,11 +26,11 @@ MEDIPS.GenomicCoordinates <- function(supersize_chr=NULL, no_chr_windows=NULL, c
 			genomeVec_pos[(supersize_chr[i-1]+1):(supersize_chr[i-1]+no_chr_windows[i])]=seq(1, chr_lengths[i], window_size)
 		}
         }
-	
-	cat("\nCreating Granges object for genome wide windows...\n")
+
+	message("\nCreating Granges object for genome wide windows...\n")
 	ROIs = GRanges(seqnames=genomeVec_chr, ranges=IRanges(start=genomeVec_pos, end=genomeVec_pos+window_size-1))
-	
+
 	gc()
 	return(ROIs)
-	
+
 }

--- a/R/MEDIPS.GenomicCoordinates.R
+++ b/R/MEDIPS.GenomicCoordinates.R
@@ -10,7 +10,7 @@
 
 MEDIPS.GenomicCoordinates <- function(supersize_chr=NULL, no_chr_windows=NULL, chromosomes=NULL, chr_lengths=NULL, window_size=NULL){
 
-	message("Calculating genomic coordinates...")
+	message("Calculating genomic coordinates...", appendLF=T)
 
 	genomeVec_chr=vector(length=supersize_chr[length(chromosomes)], mode="character")
 	genomeVec_pos=vector(length=supersize_chr[length(chromosomes)], mode="numeric")
@@ -27,7 +27,7 @@ MEDIPS.GenomicCoordinates <- function(supersize_chr=NULL, no_chr_windows=NULL, c
 		}
         }
 
-	message("\nCreating Granges object for genome wide windows...\n")
+	message("Creating Granges object for genome wide windows...", appendLF=T)
 	ROIs = GRanges(seqnames=genomeVec_chr, ranges=IRanges(start=genomeVec_pos, end=genomeVec_pos+window_size-1))
 
 	gc()

--- a/R/MEDIPS.annotate.R
+++ b/R/MEDIPS.annotate.R
@@ -3,7 +3,7 @@
 ##########################################################################
 ##Input:	Names of annotation, dataset and mart
 ##Param:	mart, dataset. annotation
-##Output:	List of annotation matrix 
+##Output:	List of annotation matrix
 ##Requires:	biomaRt
 ##Modified:	01/19/2016
 ##Author:	Joern Dietrich, Matthias Lienhard, Lukas Chavez
@@ -12,16 +12,16 @@ MEDIPS.getAnnotation<-function(host="www.ensembl.org",dataset=c("hsapiens_gene_e
 	marts=biomaRt::listMarts(host=host)
 	mart="ENSEMBL_MART_ENSEMBL"
 	if(mart%in%marts[,1])
-		cat("Getting annotation from database",as.character(marts[marts[,1]==mart,2]),"\n" )
+		message("Getting annotation from database",as.character(marts[marts[,1]==mart,2]),"\n" )
 	else
-		stop(paste("cannot find mart \"",mart,"\" at ",host,sep=""))		
+		stop(paste("cannot find mart \"",mart,"\" at ",host,sep=""))
 	biomart <- biomaRt::useMart(mart, dataset=dataset, host=host)
 	dSets=biomaRt::listDatasets(biomart)
 	if(dataset%in%dSets[,1])
-		cat("Selecting dataset",as.character(dSets[dSets[,1]==dataset,2]),"\n" )
+		message("Selecting dataset",as.character(dSets[dSets[,1]==dataset,2]),"\n" )
 	else
-		stop(paste("cannot find dataset \"",dataset,"\" at ",host,sep=""))		
-	
+		stop(paste("cannot find dataset \"",dataset,"\" at ",host,sep=""))
+
 	biomart <- biomaRt::useMart(mart, dataset,host=host)
 	Annotation=NULL
 	if(! is.null(chr)) {
@@ -32,18 +32,18 @@ MEDIPS.getAnnotation<-function(host="www.ensembl.org",dataset=c("hsapiens_gene_e
 	}else{
 		f=""
 		chr=""
-	} 
+	}
 
 	if("GENE"%in%annotation){
-		cat("...getting gene annotation\n")
+		message("...getting gene annotation\n")
 		data <- getBM(attributes=c("ensembl_gene_id","chromosome_name","start_position","end_position"),mart=biomart,filters=f, values=chr)
 		data$chromosome_name=paste("chr",data$chromosome_name,sep="")
 		names(data)=c("id", "chr", "start", "end")
 		Annotation=list("Gene"=data)
 	}
-	
+
 	if("TSS"%in%annotation){
-		cat("...getting TSS annotation\n")
+		message("...getting TSS annotation\n")
 		data <- getBM(attributes=c("ensembl_transcript_id","chromosome_name","transcript_start","transcript_end","strand"),mart=biomart,filters=f, values=chr)
 		fs=data$strand == 1 #forward strand
 		data[fs ,"transcript_end"  ]=data[fs,"transcript_start"]+tssSz[2]
@@ -55,26 +55,26 @@ MEDIPS.getAnnotation<-function(host="www.ensembl.org",dataset=c("hsapiens_gene_e
 		names(data)=c("id", "chr", "start", "end","strand")
 		Annotation=c(Annotation,list("TSS"=data[,1:4]))
 	}
-	
+
 	if("EXON"%in%annotation){
-		cat("...getting exon annotation\n")
+		message("...getting exon annotation\n")
 		data <- getBM(attributes=c("ensembl_exon_id","chromosome_name","exon_chrom_start","exon_chrom_end"),mart=biomart,filters=f, values=chr)
 		data$chromosome_name=paste("chr",data$chromosome_name,sep="")
 		names(data)=c("id", "chr", "start", "end")
 		Annotation=c(Annotation,list("EXON"=data))
 	}
-	
-	
+
+
 	return(Annotation)
 }
 
 
 ##########################################################################
-##Function to add annotation to result data regarding their position 
+##Function to add annotation to result data regarding their position
 ##########################################################################
 ##Input:	Result matrix or data.frame and list of annotation
 ##Param:	regions. annotation
-##Output:	List of annotation matrix 
+##Output:	List of annotation matrix
 ##Requires:	IRanges
 ##Modified:	11/01/2015
 ##Author:	Joern Dietrich, Matthias Lienhard
@@ -107,5 +107,3 @@ MEDIPS.setAnnotation<-function(regions, annotation, cnv=F){
 	}
 	return(ans)
 }
-
-

--- a/R/MEDIPS.annotate.R
+++ b/R/MEDIPS.annotate.R
@@ -18,7 +18,7 @@ MEDIPS.getAnnotation<-function(host="www.ensembl.org",dataset=c("hsapiens_gene_e
 	biomart <- biomaRt::useMart(mart, dataset=dataset, host=host)
 	dSets=biomaRt::listDatasets(biomart)
 	if(dataset%in%dSets[,1])
-		message("Selecting dataset", paste(as.character(dSets[dSets[,1]==dataset,2]), collapse=" ", appendLF=T)
+		message("Selecting dataset", paste(as.character(dSets[dSets[,1]==dataset,2]), collapse=" "), appendLF=T)
 	else
 		stop(paste("cannot find dataset \"",dataset,"\" at ",host,sep=""))
 

--- a/R/MEDIPS.annotate.R
+++ b/R/MEDIPS.annotate.R
@@ -12,13 +12,13 @@ MEDIPS.getAnnotation<-function(host="www.ensembl.org",dataset=c("hsapiens_gene_e
 	marts=biomaRt::listMarts(host=host)
 	mart="ENSEMBL_MART_ENSEMBL"
 	if(mart%in%marts[,1])
-		message("Getting annotation from database",as.character(marts[marts[,1]==mart,2]),"\n" )
+		message("Getting annotation from database ", paste(as.character(marts[marts[,1]==mart,2]), collapse=" "), appendLF=T)
 	else
 		stop(paste("cannot find mart \"",mart,"\" at ",host,sep=""))
 	biomart <- biomaRt::useMart(mart, dataset=dataset, host=host)
 	dSets=biomaRt::listDatasets(biomart)
 	if(dataset%in%dSets[,1])
-		message("Selecting dataset",as.character(dSets[dSets[,1]==dataset,2]),"\n" )
+		message("Selecting dataset", paste(as.character(dSets[dSets[,1]==dataset,2]), collapse=" ", appendLF=T)
 	else
 		stop(paste("cannot find dataset \"",dataset,"\" at ",host,sep=""))
 
@@ -35,7 +35,7 @@ MEDIPS.getAnnotation<-function(host="www.ensembl.org",dataset=c("hsapiens_gene_e
 	}
 
 	if("GENE"%in%annotation){
-		message("...getting gene annotation\n")
+		message("...getting gene annotation", appendLF=T)
 		data <- getBM(attributes=c("ensembl_gene_id","chromosome_name","start_position","end_position"),mart=biomart,filters=f, values=chr)
 		data$chromosome_name=paste("chr",data$chromosome_name,sep="")
 		names(data)=c("id", "chr", "start", "end")
@@ -43,7 +43,7 @@ MEDIPS.getAnnotation<-function(host="www.ensembl.org",dataset=c("hsapiens_gene_e
 	}
 
 	if("TSS"%in%annotation){
-		message("...getting TSS annotation\n")
+		message("...getting TSS annotation", appendLF=T)
 		data <- getBM(attributes=c("ensembl_transcript_id","chromosome_name","transcript_start","transcript_end","strand"),mart=biomart,filters=f, values=chr)
 		fs=data$strand == 1 #forward strand
 		data[fs ,"transcript_end"  ]=data[fs,"transcript_start"]+tssSz[2]
@@ -57,7 +57,7 @@ MEDIPS.getAnnotation<-function(host="www.ensembl.org",dataset=c("hsapiens_gene_e
 	}
 
 	if("EXON"%in%annotation){
-		message("...getting exon annotation\n")
+		message("...getting exon annotation", appendLF=T)
 		data <- getBM(attributes=c("ensembl_exon_id","chromosome_name","exon_chrom_start","exon_chrom_end"),mart=biomart,filters=f, values=chr)
 		data$chromosome_name=paste("chr",data$chromosome_name,sep="")
 		names(data)=c("id", "chr", "start", "end")

--- a/R/MEDIPS.calibrationCurve.R
+++ b/R/MEDIPS.calibrationCurve.R
@@ -16,7 +16,7 @@ MEDIPS.calibrationCurve <- function(MSet=NULL, CSet=NULL, input=FALSE){
 	coupling=	genome_CF(CSet)
 	maxCoup = floor(max(coupling)*0.8)
 
-	message("Calculating calibration curve...\n")
+	message("Calculating calibration curve...", appendLF=T)
 	mean_signal = NULL
 	coupling_level = NULL
 
@@ -62,13 +62,13 @@ MEDIPS.calibrationCurve <- function(MSet=NULL, CSet=NULL, input=FALSE){
  	if(!input){
 		##Linear curve by linear least squares regression
 		##################
-		message("Performing linear regression...\n")
+		message("Performing linear regression...", appendLF=T)
 
 		fit=lm(mean_signal[1:max_signal_index] ~ coupling_level[1:max_signal_index])
 		intercept=fit$coefficients[[1]]
 		slope=fit$coefficients[[2]]
-		message(paste("Intercept:", intercept, "\n"))
-		message(paste("Slope:", slope, "\n"))
+		message("Intercept: ", intercept, appendLF=T)
+		message("Slope:", slope, appendLF=T)
 	}
 	else{
 		intercept=NA

--- a/R/MEDIPS.calibrationCurve.R
+++ b/R/MEDIPS.calibrationCurve.R
@@ -11,22 +11,22 @@
 ##Function takes a MEDIPSset object, calculates the calibration curve and the parameters intercept and slope.
 ###############
 MEDIPS.calibrationCurve <- function(MSet=NULL, CSet=NULL, input=FALSE){
-	
+
 	signal=		genome_count(MSet)
-	coupling=	genome_CF(CSet)	
+	coupling=	genome_CF(CSet)
 	maxCoup = floor(max(coupling)*0.8)
-				
-	cat("Calculating calibration curve...\n")			
+
+	message("Calculating calibration curve...\n")
 	mean_signal = NULL
 	coupling_level = NULL
-	
+
 	count_decrease_steps = 0
 	max_signal_index = NULL
 
 	first = TRUE
 	n_coupling = 0
 
-	for(i in 1:(maxCoup+1)){		
+	for(i in 1:(maxCoup+1)){
 
 		#Test if coupling level is non-empty (can happen for ROIs)
 		if(length(signal[coupling==i-1])>0){
@@ -34,46 +34,46 @@ MEDIPS.calibrationCurve <- function(MSet=NULL, CSet=NULL, input=FALSE){
 			n_coupling = n_coupling + 1
 			mean_signal = c(mean_signal, mean(signal[coupling==i-1], trim=0.1))
 			coupling_level = c(coupling_level, i-1)
-		
+
 			##Test if mean_signal decreases
 			if(!first){
 
-				if(is.null(max_signal_index) & mean_signal[n_coupling]<mean_signal[n_coupling-1]){				
+				if(is.null(max_signal_index) & mean_signal[n_coupling]<mean_signal[n_coupling-1]){
 					count_decrease_steps=count_decrease_steps+1
 					if(count_decrease_steps==3){
-						max_signal_index=n_coupling-3		
+						max_signal_index=n_coupling-3
 					}
 				}
 				else if(is.null(max_signal_index) & mean_signal[n_coupling]>=mean_signal[n_coupling-1]){
 					count_decrease_steps=0
-				}	
+				}
 			}
 			else{
 				first = FALSE
 			}
-		} 
+		}
 		else{
-			cat(paste("Skipping coupling level ", i, " (no data).\n", sep=""))
-		}						
+			warning(paste("Skipping coupling level ", i, " (no data).\n", sep=""))
+		}
 	}
 
 	if(!input & is.null(max_signal_index)){stop("The dependency of coverage signals on sequence pattern (e.g. CpG) densities is different than expected. No linear model can be build, please check the calibration plot by providing the MSet object at ISet.")}
-				
+
  	if(!input){
 		##Linear curve by linear least squares regression
 		##################
-		cat("Performing linear regression...\n")
-			
+		message("Performing linear regression...\n")
+
 		fit=lm(mean_signal[1:max_signal_index] ~ coupling_level[1:max_signal_index])
 		intercept=fit$coefficients[[1]]
 		slope=fit$coefficients[[2]]
-		cat(paste("Intercept:", intercept, "\n"))
-		cat(paste("Slope:", slope, "\n"))
+		message(paste("Intercept:", intercept, "\n"))
+		message(paste("Slope:", slope, "\n"))
 	}
 	else{
 		intercept=NA
 		slope=NA
-	}	
+	}
 	gc()
 	return(list(mean_signal=mean_signal, coupling_level=coupling_level, max_index=max_signal_index, intercept=intercept, slope=slope))
 }

--- a/R/MEDIPS.cnv.R
+++ b/R/MEDIPS.cnv.R
@@ -97,7 +97,7 @@ MEDIPS.addCNV<-function(ISet1, ISet2, results, cnv.Frame=1000){
 	cvn.GRanges.genome = MEDIPS.GenomicCoordinates(supersize_chr, no_chr_windows, chr_names(tmp.cnv), chr_lengths(tmp.cnv), cnv.Frame)
 	base = data.frame(chr=as.vector(seqnames(cvn.GRanges.genome)), start=start(cvn.GRanges.genome), stop=end(cvn.GRanges.genome), stringsAsFactors=F)
 
-	message(paste("CNV analysis...\n", sep=" "))
+	message("CNV analysis...", appendLF=T)
 	cnv.combined = MEDIPS.cnv(base=base, rpkm.input=cnv.rpkm.input, nISets1=nISets1, nISets2=nISets2)
 
 	dummy.results = matrix(ncol=1, nrow=(nrow(base)))
@@ -106,7 +106,7 @@ MEDIPS.addCNV<-function(ISet1, ISet2, results, cnv.Frame=1000){
 	}
 	colnames(dummy.results)="CNV"
     	dummy.results=cbind(dummy.results, base)
-	
+
 	results=MEDIPS.setAnnotation(results, dummy.results, cnv=T)
 
 	rm(dummy.results)

--- a/R/MEDIPS.cnv.R
+++ b/R/MEDIPS.cnv.R
@@ -16,7 +16,7 @@ MEDIPS.cnv = function(base=base, rpkm.input=NULL, nISets1=NULL, nISets2=NULL)
 	else{
 		control.input.mean = rpkm.input[,1]
 	}
-	
+
 	if(nISets2>1){
                 treat.input.mean = rowMeans(rpkm.input[,(nISets1+1):ncol(rpkm.input)])
         }
@@ -27,93 +27,90 @@ MEDIPS.cnv = function(base=base, rpkm.input=NULL, nISets1=NULL, nISets2=NULL)
 
 	log2ratios.inputs = log2(control.input.mean/treat.input.mean)
 	cnv.ID = "ISets.mean"
-	
+
 	nperm=10000
-	alpha=0.01 
+	alpha=0.01
 	max.ones=floor(nperm*alpha)+1
 	default.DNAcopy.bdry=DNAcopy::getbdry(nperm=10000, eta=0.05,max.ones=max.ones)
   	CNA.object <- DNAcopy::CNA(log2ratios.inputs, base[,1], floor((base[,2]+base[,3])/2), data.type="logratio", sampleid=cnv.ID, presorted=TRUE)
-	
+
 	smoothed.CNA.object <- DNAcopy::smooth.CNA(CNA.object)
-	
-	segment.smoothed.CNA.object <- DNAcopy::segment(smoothed.CNA.object, verbose=2,sbdry = default.DNAcopy.bdry)				
-	
+
+	segment.smoothed.CNA.object <- DNAcopy::segment(smoothed.CNA.object, verbose=2,sbdry = default.DNAcopy.bdry)
+
 	cnv.combined = cbind(segment.smoothed.CNA.object$segRows$startRow,
-						 segment.smoothed.CNA.object$segRows$endRow, 
+						 segment.smoothed.CNA.object$segRows$endRow,
 						 segment.smoothed.CNA.object$output$seg.mean)
 	rm(CNA.object, smoothed.CNA.object, segment.smoothed.CNA.object, control.input.mean, treat.input.mean, log2ratios.inputs)
 	gc()
-	
+
 	return(cnv.combined)
 }
 
 ##########################################################################
-##Function to add results from CNV analysis 
+##Function to add results from CNV analysis
 ##########################################################################
-##Input:	Result matrix and input sets 
+##Input:	Result matrix and input sets
 ##Param:	ISet1,ISet2,results,uniq,chr,cnv.Frame
-##Output:	List of annotation matrix 
+##Output:	List of annotation matrix
 ##Requires:	BSgenome,DNAcopy
 ##Modified:	11/22/2011
 ##Author:	Joern Dietrich
 MEDIPS.addCNV<-function(ISet1, ISet2, results, cnv.Frame=1000){
 
-	nISets1 = length(ISet1)	
-	nISets2 = length(ISet2)	
-	
+	nISets1 = length(ISet1)
+	nISets2 = length(ISet2)
+
 	if(!is.list(ISet1)) ISet1=c(ISet1)
 	if(!is.list(ISet2)) ISet2=c(ISet2)
-	
+
 	cnv.rpkm.input=NULL
-	
+
 	for(i in 1:nISets1){
 		file=paste(path_name(ISet1[[i]]),sample_name(ISet1[[i]]),sep="/");
-		tmp.cnv = MEDIPS.createSet(file=file, 
-				BSgenome=genome_name(ISet1[[i]]), 
+		tmp.cnv = MEDIPS.createSet(file=file,
+				BSgenome=genome_name(ISet1[[i]]),
 				chr.select=chr_names(ISet1[[i]]),
 				extend=extend(ISet1[[i]]),
-				shift=shifted(ISet1[[i]]), 
-				uniq=uniq(ISet1[[i]]), 
+				shift=shifted(ISet1[[i]]),
+				uniq=uniq(ISet1[[i]]),
 				window_size=cnv.Frame)
-		
-		cnv.rpkm.input = cbind(cnv.rpkm.input, ((genome_count(tmp.cnv)*10^9)/(cnv.Frame*number_regions(tmp.cnv))))	
+
+		cnv.rpkm.input = cbind(cnv.rpkm.input, ((genome_count(tmp.cnv)*10^9)/(cnv.Frame*number_regions(tmp.cnv))))
 	}
-	
+
 	for(i in 1:nISets2){
 		file=paste(path_name(ISet2[[i]]),sample_name(ISet2[[i]]),sep="/");
-		tmp.cnv = MEDIPS.createSet(file=file, 
+		tmp.cnv = MEDIPS.createSet(file=file,
 				BSgenome=genome_name(ISet2[[i]]),
-				chr.select=chr_names(ISet2[[i]]), 
-				extend=extend(ISet2[[i]]), 
+				chr.select=chr_names(ISet2[[i]]),
+				extend=extend(ISet2[[i]]),
 				shift=shifted(ISet2[[i]]),
-				uniq=uniq(ISet2[[i]]), 
+				uniq=uniq(ISet2[[i]]),
 				window_size=cnv.Frame)
-		
-		cnv.rpkm.input = cbind(cnv.rpkm.input, ((genome_count(tmp.cnv)*10^9)/(cnv.Frame*number_regions(tmp.cnv))))	
+
+		cnv.rpkm.input = cbind(cnv.rpkm.input, ((genome_count(tmp.cnv)*10^9)/(cnv.Frame*number_regions(tmp.cnv))))
 	}
-							           							           
+
 	no_chr_windows = ceiling(chr_lengths(tmp.cnv)/cnv.Frame)
 	supersize_chr = cumsum(no_chr_windows)
 	cvn.GRanges.genome = MEDIPS.GenomicCoordinates(supersize_chr, no_chr_windows, chr_names(tmp.cnv), chr_lengths(tmp.cnv), cnv.Frame)
 	base = data.frame(chr=as.vector(seqnames(cvn.GRanges.genome)), start=start(cvn.GRanges.genome), stop=end(cvn.GRanges.genome), stringsAsFactors=F)
-	
-	cat(paste("CNV analysis...\n", sep=" "))
+
+	message(paste("CNV analysis...\n", sep=" "))
 	cnv.combined = MEDIPS.cnv(base=base, rpkm.input=cnv.rpkm.input, nISets1=nISets1, nISets2=nISets2)
-	
+
 	dummy.results = matrix(ncol=1, nrow=(nrow(base)))
 	for(i in 1:nrow(cnv.combined)){
-		dummy.results[cnv.combined[i,1]:cnv.combined[i,2]] = cnv.combined[i,3]		
+		dummy.results[cnv.combined[i,1]:cnv.combined[i,2]] = cnv.combined[i,3]
 	}
 	colnames(dummy.results)="CNV"
     	dummy.results=cbind(dummy.results, base)
 	
 	results=MEDIPS.setAnnotation(results, dummy.results, cnv=T)
-	
-	rm(dummy.results)	
+
+	rm(dummy.results)
 	gc()
-	
+
 	return(results)
 }
-
-
-

--- a/R/MEDIPS.couplingVector.R
+++ b/R/MEDIPS.couplingVector.R
@@ -26,7 +26,7 @@ MEDIPS.couplingVector <- function(pattern="CG", refObj=NULL){
 	}
 
 	## Get the genomic positions of the sequence pattern
-	message("Get genomic sequence pattern positions...\n")
+	message("Get genomic sequence pattern positions...", appendLF=T)
 	GRanges.pattern = MEDIPS.getPositions(BSgenome, pattern, chromosomes)
 
 	## Create the genome vector Granges object
@@ -41,7 +41,7 @@ MEDIPS.couplingVector <- function(pattern="CG", refObj=NULL){
 	}
 
 	##Count the number of sequence pattern in each window.
-	message(paste("Counting the number of ",pattern, "'s in each window...\n", sep=""))
+	message("Counting the number of ", pattern, "'s in each window...", appendLF=T)
 	genomeCoup = countOverlaps(Granges.genomeVec, GRanges.pattern)
 
 	COUPLINGsetObj = new('COUPLINGset', seq_pattern=pattern, genome_name=BSgenome, genome_CF=genomeCoup, number_pattern=length(GRanges.pattern), window_size=window_size, chr_names=chromosomes, chr_lengths=chr_lengths)

--- a/R/MEDIPS.couplingVector.R
+++ b/R/MEDIPS.couplingVector.R
@@ -9,7 +9,7 @@
 ##Modified:	01/09/2015
 ##Author:	Lukas Chavez
 
-MEDIPS.couplingVector <- function(pattern="CG", refObj=NULL){	
+MEDIPS.couplingVector <- function(pattern="CG", refObj=NULL){
 	if(is.list(refObj)){
 		refObj=refObj[[1]]
 	}
@@ -26,26 +26,26 @@ MEDIPS.couplingVector <- function(pattern="CG", refObj=NULL){
 	}
 
 	## Get the genomic positions of the sequence pattern
-	cat("Get genomic sequence pattern positions...\n")
+	message("Get genomic sequence pattern positions...\n")
 	GRanges.pattern = MEDIPS.getPositions(BSgenome, pattern, chromosomes)
-	
-	## Create the genome vector Granges object	
+
+	## Create the genome vector Granges object
 	if(class(refObj)=="MEDIPSset"){
 		window_size = window_size(refObj)
 		no_chr_windows = ceiling(chr_lengths/window_size)
-		supersize_chr = cumsum(no_chr_windows)	
-		Granges.genomeVec = MEDIPS.GenomicCoordinates(supersize_chr, no_chr_windows, chromosomes, chr_lengths, window_size)	
+		supersize_chr = cumsum(no_chr_windows)
+		Granges.genomeVec = MEDIPS.GenomicCoordinates(supersize_chr, no_chr_windows, chromosomes, chr_lengths, window_size)
 	}else{	#this means: class(refObj)=="MEDIPSroiSet"
 		Granges.genomeVec = rois(refObj)
 		window_size=-1
 	}
-			
+
 	##Count the number of sequence pattern in each window.
-	cat(paste("Counting the number of ",pattern, "'s in each window...\n", sep=""))
-	genomeCoup = countOverlaps(Granges.genomeVec, GRanges.pattern) 
+	message(paste("Counting the number of ",pattern, "'s in each window...\n", sep=""))
+	genomeCoup = countOverlaps(Granges.genomeVec, GRanges.pattern)
 
 	COUPLINGsetObj = new('COUPLINGset', seq_pattern=pattern, genome_name=BSgenome, genome_CF=genomeCoup, number_pattern=length(GRanges.pattern), window_size=window_size, chr_names=chromosomes, chr_lengths=chr_lengths)
 	gc()
-	
-	return(COUPLINGsetObj)	
+
+	return(COUPLINGsetObj)
 }

--- a/R/MEDIPS.createROIset.R
+++ b/R/MEDIPS.createROIset.R
@@ -9,60 +9,60 @@
 ##Author:	Lukas Chavez
 
 MEDIPS.createROIset <- function(file=NULL, ROI=NULL, extend=0, shift=0, bn=1, BSgenome=NULL, uniq=1e-3, chr.select=NULL, paired=F, sample_name=NULL, isSecondaryAlignment = FALSE, simpleCigar=TRUE){
-			
+
 	## Proof of correctness....
 	if(is.null(BSgenome)){stop("Must specify a BSgenome library.")}
 	if(is.null(file)){stop("Must specify a bam or txt file.")}
-		
-	## Read region file		
+
+	## Read region file
 	fileName=unlist(strsplit(file, "/"))[length(unlist(strsplit(file, "/")))]
-	path=paste(unlist(strsplit(file, "/"))[1:(length(unlist(strsplit(file, "/"))))-1], collapse="/") 
+	path=paste(unlist(strsplit(file, "/"))[1:(length(unlist(strsplit(file, "/"))))-1], collapse="/")
 	if(path==""){path=getwd()}
-		
+
 	if(!fileName%in%dir(path)){stop(paste("File", fileName, " not found in", path, sep =" "))}
 
 	dataset=get(ls(paste("package:", BSgenome, sep="")))
 
 	#Check chromosomes in ROI file and in chr.select
 	if(is.null(ROI)){
-		stop("Regions of interest (ROI) required.")		
+		stop("Regions of interest (ROI) required.")
 	}
-	
+
 	chromosomes=as.character(unique(ROI[,1]))
-	
+
 	#Test, if the roi file contains chromosomes also in the BSgenome reference
 	if(sum(!chromosomes%in%seqnames(dataset))!=0){
-               	cat("The chromosome(s)", chromosomes[!chromosomes%in%seqnames(dataset)], "are not available in the BSgenome reference. Chromosomes available in the BSgenome reference:", seqnames(dataset), "\n")
+               	error("The chromosome(s)", chromosomes[!chromosomes%in%seqnames(dataset)], "are not available in the BSgenome reference. Chromosomes available in the BSgenome reference:", seqnames(dataset), "\n")
                        stop("Please check the ROI object.")
-	} 
-	
+	}
+
 	#Test, if chr.select contains chromosomes only in ROI
 	if(!is.null(chr.select) & sum(!chr.select%in%chromosomes)!=0){
-		cat("The chromosome(s)", chr.select[!chr.select%in%chromosomes], "are not available in the ROI object. Chromosomes available in the ROI object:", chromosomes, "\n")
+		error("The chromosome(s)", chr.select[!chr.select%in%chromosomes], "are not available in the ROI object. Chromosomes available in the ROI object:", chromosomes, "\n")
 		stop("Please check chromosome selection.")
 	}
-	
+
 	#Shorten ROI by chr.select, if required
 	if(!is.null(chr.select) & sum(!chr.select%in%chromosomes)==0){
 		ROI=ROI[ROI[,1] %in% chr.select,]
 		chromosomes=as.character(unique(ROI[,1]))
 	}
-	
+
 	## Sort chromosomes
         if(length(chromosomes)>1){chromosomes=mixedsort(chromosomes)}
-	
+
 	if(!paired){GRange.Reads = getGRange(fileName, path, extend, shift, chromosomes, dataset, uniq, ROI=ROI, isSecondaryAlignment = isSecondaryAlignment, simpleCigar=simpleCigar)}
 	else{GRange.Reads = getPairedGRange(fileName, path, extend, shift, chromosomes, dataset, uniq, ROI=ROI, isSecondaryAlignment = isSecondaryAlignment, simpleCigar=simpleCigar)}
-				
-	## Get chromosome lengths for all chromosomes within data set.
-	cat(paste("Loading chromosome lengths for ",BSgenome, "...\n", sep=""))		
-	dataset=get(ls(paste("package:", BSgenome, sep="")))
-	chr_lengths=as.numeric(seqlengths(dataset)[chromosomes])	
 
-	## Create the ROI Granges object	
+	## Get chromosome lengths for all chromosomes within data set.
+	cat(paste("Loading chromosome lengths for ",BSgenome, "...\n", sep=""))
+	dataset=get(ls(paste("package:", BSgenome, sep="")))
+	chr_lengths=as.numeric(seqlengths(dataset)[chromosomes])
+
+	## Create the ROI Granges object
 	ROI = data.frame(chr=as.character(ROI[,1]), start=ROI[,2], end=ROI[,3], ID=as.character(ROI[,4]))
         Granges.genomeVec  = bin.ROIs(ROI=ROI, binNo=bn)
-		
+
 	##Distribute reads over roi's
 	cat("Calculating short read coverage at regions of interest...\n")
 	overlap = countOverlaps(Granges.genomeVec, GRange.Reads)
@@ -71,22 +71,22 @@ MEDIPS.createROIset <- function(file=NULL, ROI=NULL, extend=0, shift=0, bn=1, BS
 	if(is.null(sample_name)){
 		sample_name = fileName
 	}
-			
+
 	## creating MEDIPSset object
     	MEDIPSroiSetObj = new('MEDIPSroiSet', sample_name=sample_name,
 				                        path_name=path,
-				                        genome_name=BSgenome, 
-							number_regions=length(GRange.Reads), 
-							chr_names=chromosomes, 
-							chr_lengths=chr_lengths, 
-							genome_count=overlap, 
+				                        genome_name=BSgenome,
+							number_regions=length(GRange.Reads),
+							chr_names=chromosomes,
+							chr_lengths=chr_lengths,
+							genome_count=overlap,
 							extend=extend,
-							shifted=shift, 
+							shifted=shift,
 							bin_number=bn,
 							uniq=uniq,
 							ROI=Granges.genomeVec)
     	gc()
-	return(MEDIPSroiSetObj) 	
+	return(MEDIPSroiSetObj)
 }
 
 
@@ -99,38 +99,36 @@ MEDIPS.createROIset <- function(file=NULL, ROI=NULL, extend=0, shift=0, bn=1, BS
 ##Modified: 14/10/2011
 ##Author: Lukas Chavez
 bin.ROIs = function(ROI=NULL, binNo=NULL){
-	
+
 	chr=as.character(ROI[,1])
 	start=as.numeric(ROI[,2])
 	stop=as.numeric(ROI[,3])
-	name=as.character(ROI[,4])	
-	
+	name=as.character(ROI[,4])
+
 	result.ext = matrix(ncol=4, nrow=length(chr)*binNo)
 
 	if(binNo>1){
 		for(i in 1:length(chr)){
-		
+
 			interval.positions = floor(seq(start[i], stop[i], length.out=binNo+1))
 			start.ext=interval.positions[c(1:length(interval.positions)-1)]
 			start.ext[2:length(start.ext)]=start.ext[2:length(start.ext)]+1
 			stop.ext=interval.positions[c(2:length(interval.positions))]
-	
-			result.ext[c(((i-1)*binNo+1):(i*binNo)),1] = chr[i]	
+
+			result.ext[c(((i-1)*binNo+1):(i*binNo)),1] = chr[i]
 			result.ext[c(((i-1)*binNo+1):(i*binNo)),2] = start.ext
-			result.ext[c(((i-1)*binNo+1):(i*binNo)),3] = stop.ext	
-			result.ext[c(((i-1)*binNo+1):(i*binNo)),4] = paste(name[i], seq(1,binNo), sep="_")	
+			result.ext[c(((i-1)*binNo+1):(i*binNo)),3] = stop.ext
+			result.ext[c(((i-1)*binNo+1):(i*binNo)),4] = paste(name[i], seq(1,binNo), sep="_")
 		}
 	} else{
 		result.ext[,1] = chr
 		result.ext[,2] = start
 		result.ext[,3] = stop
-		result.ext[,4] = name		
+		result.ext[,4] = name
 	}
-	
+
 	binROIs = GRanges(seqnames=result.ext[,1], ranges=IRanges(start=as.numeric(result.ext[,2]), end=as.numeric(result.ext[,3]), names=result.ext[,4]))
-	
+
 	return(binROIs)
 
 }
-
-

--- a/R/MEDIPS.createSet.R
+++ b/R/MEDIPS.createSet.R
@@ -28,9 +28,9 @@ function (file = NULL, extend = 0, shift = 0, window_size = 300,
     }
     dataset = get(ls(paste("package:", BSgenome, sep = "")))
     if (is.null(chr.select)) {
-        message("All chromosomes in the reference BSgenome will be processed:\n")
+        message("All chromosomes in the reference BSgenome will be processed:", appendLF=T)
         chr.select = seqnames(dataset)
-        message(paste(chr.select, collapse='\t'))
+        message(paste(chr.select, collapse='\t'), appendLF=T)
     }
     else {
         if (sum(!chr.select %in% seqnames(dataset)) != 0) {
@@ -68,7 +68,7 @@ function (file = NULL, extend = 0, shift = 0, window_size = 300,
         Granges.genomeVec = MEDIPS.GenomicCoordinates(supersize_chr,
             no_chr_windows, chr.select, chr_lengths, window_size)
 
-        message("Calculating short read coverage at genome wide windows...\n")
+        message("Calculating short read coverage at genome wide windows...", appendLF=T)
         overlap = countOverlaps(Granges.genomeVec, GRange.Reads)
         datachr = unique(seqlevels(GRange.Reads))
 

--- a/R/MEDIPS.createSet.R
+++ b/R/MEDIPS.createSet.R
@@ -9,9 +9,9 @@
 ##Author:	Lukas Chavez, Matthias Lienhard, Isaac Lopez Moyado
 
 MEDIPS.createSet <-
-function (file = NULL, extend = 0, shift = 0, window_size = 300, 
-    BSgenome = NULL, uniq = 1e-3, chr.select = NULL, paired = F, 
-    sample_name = NULL, isSecondaryAlignment = FALSE, simpleCigar=TRUE) 
+function (file = NULL, extend = 0, shift = 0, window_size = 300,
+    BSgenome = NULL, uniq = 1e-3, chr.select = NULL, paired = F,
+    sample_name = NULL, isSecondaryAlignment = FALSE, simpleCigar=TRUE)
 {
     if (is.null(BSgenome)) {
         stop("Must specify a BSgenome library.")
@@ -19,23 +19,23 @@ function (file = NULL, extend = 0, shift = 0, window_size = 300,
     if (is.null(file)) {
         stop("Must specify a bam or txt file.")
     }
-    fileName = unlist(strsplit(file, "/"))[length(unlist(strsplit(file, 
+    fileName = unlist(strsplit(file, "/"))[length(unlist(strsplit(file,
         "/")))]
-    path = paste(unlist(strsplit(file, "/"))[1:(length(unlist(strsplit(file, 
+    path = paste(unlist(strsplit(file, "/"))[1:(length(unlist(strsplit(file,
         "/")))) - 1], collapse = "/")
     if (path == "") {
         path = getwd()
     }
     dataset = get(ls(paste("package:", BSgenome, sep = "")))
     if (is.null(chr.select)) {
-        cat("All chromosomes in the reference BSgenome will be processed:\n")
+        message("All chromosomes in the reference BSgenome will be processed:\n")
         chr.select = seqnames(dataset)
-        print(chr.select)
+        message(paste(chr.select, collapse='\t'))
     }
     else {
         if (sum(!chr.select %in% seqnames(dataset)) != 0) {
-            cat("The requested chromosome(s)", chr.select[!chr.select %in% 
-                seqnames(dataset)], "are not available in the BSgenome reference. Chromosomes available in the BSgenome reference:", 
+            error("The requested chromosome(s)", chr.select[!chr.select %in%
+                seqnames(dataset)], "are not available in the BSgenome reference. Chromosomes available in the BSgenome reference:",
                 seqnames(dataset), "\n")
             stop("Please check chromosome names.")
         }
@@ -47,44 +47,44 @@ function (file = NULL, extend = 0, shift = 0, window_size = 300,
         stop(paste("File", fileName, " not found in", path, sep = " "))
     }
     ext = strsplit(fileName, ".", fixed = T)[[1]]
-    if (ext[length(ext)] %in% c("gz", "zip", "bz2")) 
+    if (ext[length(ext)] %in% c("gz", "zip", "bz2"))
         ext = ext[-length(ext)]
     if (ext[length(ext)] %in% c("wig", "bw", "bigwig")) {
-        MEDIPSsetObj = getMObjectFromWIG(fileName, path, chr.select, 
+        MEDIPSsetObj = getMObjectFromWIG(fileName, path, chr.select,
             BSgenome)
     }
     else {
         if (!paired) {
-            GRange.Reads = getGRange(fileName, path, extend, 
+            GRange.Reads = getGRange(fileName, path, extend,
                 shift, chr.select, dataset, uniq, isSecondaryAlignment = isSecondaryAlignment, simpleCigar=simpleCigar)
         }
         else {
-            GRange.Reads = getPairedGRange(fileName, path, extend, 
+            GRange.Reads = getPairedGRange(fileName, path, extend,
                 shift, chr.select, dataset, uniq, isSecondaryAlignment = isSecondaryAlignment, simpleCigar=simpleCigar)
         }
         chr_lengths = as.numeric(seqlengths(dataset)[chr.select])
         no_chr_windows = ceiling(chr_lengths/window_size)
         supersize_chr = cumsum(no_chr_windows)
-        Granges.genomeVec = MEDIPS.GenomicCoordinates(supersize_chr, 
+        Granges.genomeVec = MEDIPS.GenomicCoordinates(supersize_chr,
             no_chr_windows, chr.select, chr_lengths, window_size)
-        
-        cat("Calculating short read coverage at genome wide windows...\n")
+
+        message("Calculating short read coverage at genome wide windows...\n")
         overlap = countOverlaps(Granges.genomeVec, GRange.Reads)
         datachr = unique(seqlevels(GRange.Reads))
-       
+
         if (sum(!chr.select %in% datachr) != 0) {
-            cat("Please note, no data in the alignment file for chromosome(s):", 
+            warning("Please note, no data in the alignment file for chromosome(s):",
                 chr.select[!chr.select %in% datachr], "\n")
         }
-       
+
         if (is.null(sample_name)) {
             sample_name = fileName
         }
 
-        MEDIPSsetObj = new("MEDIPSset", sample_name = sample_name, 
-            path_name = path, genome_name = BSgenome, number_regions = length(GRange.Reads), 
-            chr_names = chr.select, chr_lengths = chr_lengths, 
-            genome_count = overlap, extend = extend, shifted = shift, 
+        MEDIPSsetObj = new("MEDIPSset", sample_name = sample_name,
+            path_name = path, genome_name = BSgenome, number_regions = length(GRange.Reads),
+            chr_names = chr.select, chr_lengths = chr_lengths,
+            genome_count = overlap, extend = extend, shifted = shift,
             window_size = window_size, uniq = uniq)
     }
     return(MEDIPSsetObj)

--- a/R/MEDIPS.diffMeth.R
+++ b/R/MEDIPS.diffMeth.R
@@ -15,30 +15,30 @@ MEDIPS.diffMeth = function(base = NULL, values=NULL, diff.method="ttest", nMSets
 	if(diff.method=="edgeR"){
 
 		##Extract non-zero MeDIP count windows
-		message(paste("Extracting count windows with at least", minRowSum, "reads...\n", sep=" "))
+		message("Extracting count windows with at least ", minRowSum, " reads...", appendLF=T)
 		filter= rowSums(values)>=minRowSum
 
 		##Extract non-zero coupling factor rows
 		if(MeDIP){
-			message(paste("Extracting non-zero coupling factor windows...\n", sep=" "))
+			message("Extracting non-zero coupling factor windows...", appendLF=T)
 			filter=filter & base[,4]!=0
 		}
 
-		message(paste("Execute edgeR for count data of", sum(filter), "windows...\n", sep=" "))
-		message("(Neglecting parameter 'type')\n")
+		message("Execute edgeR for count data of ", sum(filter), " windows...", appendLF=T)
+		message("(Neglecting parameter 'type')", appendLF=T)
 
-		message("Creating a DGEList object...\n")
+		message("Creating a DGEList object...", appendLF=T)
 		edRObj.group=c(rep(1, nMSets1), rep(2, nMSets2))
 		edRObj.length=c(n.r.M1, n.r.M2)
 		#d <- edgeR::DGEList(counts = values[filter,], group = edRObj.group, lib.size=edRObj.length)
 		d <- edgeR::DGEList(counts = values[filter,], group = edRObj.group)
 
 		if(diffnorm=="tmm"){
-			message("Apply trimmed mean of M-values (TMM) for library sizes normalization...\n")
+			message("Apply trimmed mean of M-values (TMM) for library sizes normalization...", appendLF=T)
 			d=edgeR::calcNormFactors(d)
 		}
 		if(diffnorm=="quantile" | diffnorm=="none"){
-			message("Skipping trimmed mean of M-values (TMM) library size normalization...\n")
+			message("Skipping trimmed mean of M-values (TMM) library size normalization...", appendLF=T)
 			d=edgeR::calcNormFactors(d, method="none")
 		}
 	    if(diffnorm!="tmm" & diffnorm!="quantile" & diffnorm!="none"){
@@ -46,23 +46,23 @@ MEDIPS.diffMeth = function(base = NULL, values=NULL, diff.method="ttest", nMSets
 	    }
 
 		if(nMSets1!=1 | nMSets2!=1){
-			message("Estimating common dispersion...\n")
+			message("Estimating common dispersion...", appendLF=T)
 			d=edgeR::estimateCommonDisp(d)
-			message("Estimating tagwise dispersion...\n")
+			message("Estimating tagwise dispersion...", appendLF=T)
 			d=edgeR::estimateTagwiseDisp(d)
-			message("Calculating differential coverage...\n")
+			message("Calculating differential coverage...", appendLF=T)
 			de.com=edgeR::exactTest(d,pair=c("2","1"))
 		}
 		else{
 			warning("There is no replication, setting dispersion to bcv^2 where bcv=0.01.\n")
 			warning("Please consider http://www.bioconductor.org/packages/release/bioc/vignettes/edgeR/inst/doc/edgeRUsersGuide.pdf section 2.9.\n")
 			bcv = 0.01
-			message("Calculating differential coverage...\n")
+			message("Calculating differential coverage...", appendLF=T)
 			de.com = suppressWarnings(edgeR::exactTest(d, dispersion=bcv^2, pair=c("2","1")))
 		}
 
 		##Adjusting p.values for multiple testing
-		message(paste("Adjusting p.values for multiple testing...\n", sep=" "))
+		message("Adjusting p.values for multiple testing...", appendLF=T)
 		colnames(de.com$table) = c("edgeR.logFC", "edgeR.logCPM", "edgeR.p.value")
 		diff.results = cbind(de.com$table, edgeR.adj.p.value=p.adjust(de.com$table$edgeR.p.value, p.adj))
 
@@ -74,13 +74,13 @@ MEDIPS.diffMeth = function(base = NULL, values=NULL, diff.method="ttest", nMSets
 	#########
 	else{
 		##Extract non-zero MeDIP rows
-		message(paste("Extracting count windows with at least",minRowSum," reads...\n", sep=" "))
+		message("Extracting count windows with at least ",minRowSum, " reads...", appendLF=T)
 
 		filter= rowSums(values)>=minRowSum
 
 		##Extract non-zero coupling factor windows
 		if(MeDIP){
-			message(paste("Extracting non-zero coupling factor windows...\n", sep=" "))
+			message("Extracting non-zero coupling factor windows...", appendLF=T)
 			filter=filter & base[,4]!=0
 		}
 
@@ -89,7 +89,7 @@ MEDIPS.diffMeth = function(base = NULL, values=NULL, diff.method="ttest", nMSets
 		filter=filter & !is.na(rowSums(values))
 
 
-		message(paste("Calculating score for", sum(filter), "windows...\n", sep=" "))
+		message("Calculating score for ", sum(filter), " windows...", appendLF=T)
 		ms1=1:nMSets1
 		ms2=(nMSets1+1):(nMSets1+nMSets2)
 		##Calculate ratios##
@@ -113,7 +113,7 @@ MEDIPS.diffMeth = function(base = NULL, values=NULL, diff.method="ttest", nMSets
 		score = (-log10(t.test.p.value)*10)*log(ratio)
 
 		##Adjusting p.values for multiple testing
-		message(paste("Adjusting p.values for multiple testing...\n", sep=" "))	
+		message("Adjusting p.values for multiple testing...", appendLF=T)
 
 		diff.results = cbind(score.log2.ratio=log2(ratio), score.p.value=t.test.p.value, score.adj.p.value=p.adjust(t.test.p.value, p.adj), score=score)
 

--- a/R/MEDIPS.diffMeth.R
+++ b/R/MEDIPS.diffMeth.R
@@ -12,33 +12,33 @@ MEDIPS.diffMeth = function(base = NULL, values=NULL, diff.method="ttest", nMSets
 {
 	##edgeR##
 	#########
-	if(diff.method=="edgeR"){		
-			
+	if(diff.method=="edgeR"){
+
 		##Extract non-zero MeDIP count windows
-		cat(paste("Extracting count windows with at least", minRowSum, "reads...\n", sep=" "))
+		message(paste("Extracting count windows with at least", minRowSum, "reads...\n", sep=" "))
 		filter= rowSums(values)>=minRowSum
 
 		##Extract non-zero coupling factor rows
 		if(MeDIP){
-			cat(paste("Extracting non-zero coupling factor windows...\n", sep=" "))
+			message(paste("Extracting non-zero coupling factor windows...\n", sep=" "))
 			filter=filter & base[,4]!=0
 		}
 
-		cat(paste("Execute edgeR for count data of", sum(filter), "windows...\n", sep=" "))
-		cat("(Neglecting parameter 'type')\n")
+		message(paste("Execute edgeR for count data of", sum(filter), "windows...\n", sep=" "))
+		message("(Neglecting parameter 'type')\n")
 
-		cat("Creating a DGEList object...\n")						
+		message("Creating a DGEList object...\n")
 		edRObj.group=c(rep(1, nMSets1), rep(2, nMSets2))
 		edRObj.length=c(n.r.M1, n.r.M2)
 		#d <- edgeR::DGEList(counts = values[filter,], group = edRObj.group, lib.size=edRObj.length)
 		d <- edgeR::DGEList(counts = values[filter,], group = edRObj.group)
 
 		if(diffnorm=="tmm"){
-			cat("Apply trimmed mean of M-values (TMM) for library sizes normalization...\n")	
+			message("Apply trimmed mean of M-values (TMM) for library sizes normalization...\n")
 			d=edgeR::calcNormFactors(d)
 		}
 		if(diffnorm=="quantile" | diffnorm=="none"){
-			cat("Skipping trimmed mean of M-values (TMM) library size normalization...\n")	
+			message("Skipping trimmed mean of M-values (TMM) library size normalization...\n")
 			d=edgeR::calcNormFactors(d, method="none")
 		}
 	    if(diffnorm!="tmm" & diffnorm!="quantile" & diffnorm!="none"){
@@ -46,56 +46,56 @@ MEDIPS.diffMeth = function(base = NULL, values=NULL, diff.method="ttest", nMSets
 	    }
 
 		if(nMSets1!=1 | nMSets2!=1){
-			cat("Estimating common dispersion...\n")			
+			message("Estimating common dispersion...\n")
 			d=edgeR::estimateCommonDisp(d)
-			cat("Estimating tagwise dispersion...\n")	
+			message("Estimating tagwise dispersion...\n")
 			d=edgeR::estimateTagwiseDisp(d)
-			cat("Calculating differential coverage...\n")
+			message("Calculating differential coverage...\n")
 			de.com=edgeR::exactTest(d,pair=c("2","1"))
 		}
 		else{
-			cat("There is no replication, setting dispersion to bcv^2 where bcv=0.01.\n")
-			cat("Please consider http://www.bioconductor.org/packages/release/bioc/vignettes/edgeR/inst/doc/edgeRUsersGuide.pdf section 2.9.\n")
+			warning("There is no replication, setting dispersion to bcv^2 where bcv=0.01.\n")
+			warning("Please consider http://www.bioconductor.org/packages/release/bioc/vignettes/edgeR/inst/doc/edgeRUsersGuide.pdf section 2.9.\n")
 			bcv = 0.01
-			cat("Calculating differential coverage...\n")
+			message("Calculating differential coverage...\n")
 			de.com = suppressWarnings(edgeR::exactTest(d, dispersion=bcv^2, pair=c("2","1")))
 		}
-		
+
 		##Adjusting p.values for multiple testing
-		cat(paste("Adjusting p.values for multiple testing...\n", sep=" "))
-		colnames(de.com$table) = c("edgeR.logFC", "edgeR.logCPM", "edgeR.p.value")		
-		diff.results = cbind(de.com$table, edgeR.adj.p.value=p.adjust(de.com$table$edgeR.p.value, p.adj)) 
-		
+		message(paste("Adjusting p.values for multiple testing...\n", sep=" "))
+		colnames(de.com$table) = c("edgeR.logFC", "edgeR.logCPM", "edgeR.p.value")
+		diff.results = cbind(de.com$table, edgeR.adj.p.value=p.adjust(de.com$table$edgeR.p.value, p.adj))
+
 		rm(de.com, edRObj.group, edRObj.length, d)
 		gc()
 	}
-		
+
 	##ttest/Score##
 	#########
-	else{			
+	else{
 		##Extract non-zero MeDIP rows
-		cat(paste("Extracting count windows with at least",minRowSum," reads...\n", sep=" "))
+		message(paste("Extracting count windows with at least",minRowSum," reads...\n", sep=" "))
 
 		filter= rowSums(values)>=minRowSum
 
 		##Extract non-zero coupling factor windows
 		if(MeDIP){
-			cat(paste("Extracting non-zero coupling factor windows...\n", sep=" "))
+			message(paste("Extracting non-zero coupling factor windows...\n", sep=" "))
 			filter=filter & base[,4]!=0
 		}
-	
+
 		#filter NA
 		#if there is a na in a row, this row is sorted out?!
 		filter=filter & !is.na(rowSums(values))
 
-			
-		cat(paste("Calculating score for", sum(filter), "windows...\n", sep=" "))
+
+		message(paste("Calculating score for", sum(filter), "windows...\n", sep=" "))
 		ms1=1:nMSets1
 		ms2=(nMSets1+1):(nMSets1+nMSets2)
 		##Calculate ratios##
 		####################
 		ratio=rowSums(values[filter,ms1]+0.1)/rowSums(values[filter,ms2,drop=F]+0.1)*(nMSets2/nMSets1)
-	
+
 		##Calculate p.values##
 		######################
 		##Check for constant entries
@@ -104,22 +104,21 @@ MEDIPS.diffMeth = function(base = NULL, values=NULL, diff.method="ttest", nMSets
 		const = apply(X=values[filter,ms1,drop=F],MARGIN=1,FUN=min) - apply(X=values[filter,ms1,drop=F],MARGIN=1,FUN=max) 	+
 			apply(X=values[filter,ms2,drop=F],MARGIN=1,FUN=min) - apply(X=values[filter,ms2,drop=F],MARGIN=1,FUN=max) 	== 0
 
-		t.test.p.value = rep(NA, sum(filter))				
+		t.test.p.value = rep(NA, sum(filter))
 
 		t.test.p.value[!const]=matTtest(values[filter,][!const,],groups=c(rep(1,nMSets1),rep(2,nMSets2)))$p.value
 
 		##Calculate the final score##
 		#############################
 		score = (-log10(t.test.p.value)*10)*log(ratio)
-		
+
 		##Adjusting p.values for multiple testing
-		cat(paste("Adjusting p.values for multiple testing...\n", sep=" "))	
-			
+		message(paste("Adjusting p.values for multiple testing...\n", sep=" "))	
+
 		diff.results = cbind(score.log2.ratio=log2(ratio), score.p.value=t.test.p.value, score.adj.p.value=p.adjust(t.test.p.value, p.adj), score=score)
-			
+
 		rm(const, ratio, t.test.p.value, score)
-		
-	}		
+
+	}
 	return(list(diff.results=diff.results, diff.index=which(filter)))
 }
-

--- a/R/MEDIPS.exportWIG.R
+++ b/R/MEDIPS.exportWIG.R
@@ -65,7 +65,7 @@ function(Set=NULL, CSet=NULL, file=NULL, format="rpkm", descr=""){
 	write.table(header_out, file=file, sep="", quote=F, row.names=F, col.names=F)
 
 	for(i in 1:length(chr_names)){
-		message(paste("Writing data for ", chr_names[i], "...\n", sep=""))
+		message(paste("Writing data for ", chr_names[i], "...", collapse="\t"))
 		chr_header=paste("fixedStep chrom=", chr_names[i]," start=1 step=", window_size, " span=",  window_size, sep="")
 		write.table(chr_header, file=file, sep="", quote=F, row.names=F, col.names=F, append=T)
 		temp_data=output_data[genome_chr==chr_names[i]]

--- a/R/MEDIPS.exportWIG.R
+++ b/R/MEDIPS.exportWIG.R
@@ -9,40 +9,40 @@
 
 MEDIPS.exportWIG <-
 function(Set=NULL, CSet=NULL, file=NULL, format="rpkm", descr=""){
-	
+
 	##Proof for correctness
 	########################
 	if(is.null(file)){stop("Must specify an output file!")}
 	if(format != "count" & format!= "rpkm" & format != "pdensity" & format != "rms"){stop("Format pareeter must be either count, rpkm or pdensity!")}
-	
+
 	##Set sample names and output data
 	###################################
-	if(format=="pdensity"){		
+	if(format=="pdensity"){
 		if(class(CSet)!="COUPLINGset"){stop("For exporting pattern densities, you have to specify a COUPLINGset object at CSet!")}
 		window_size=window_size(CSet)
 		chr_names=chr_names(CSet)
 		chr_lengths=chr_lengths(CSet)
 		chromosomes=chr_names(CSet)
 		output_data = genome_CF(CSet)
-		header_out=paste("track type=wiggle_0 name=\"", descr, "\" description=\"", descr, "\" visibility=full autoScale=on color=0,200,100 maxHeightPixels=100:50:20 graphType=bar priority=20", sep="")			
+		header_out=paste("track type=wiggle_0 name=\"", descr, "\" description=\"", descr, "\" visibility=full autoScale=on color=0,200,100 maxHeightPixels=100:50:20 graphType=bar priority=20", sep="")
 	}
-	else if(format=="count"){	
+	else if(format=="count"){
 		if(class(Set)!="MEDIPSset"){stop("For exporting count data, you have to specify a MEDIPSset object at Set!")}
 		window_size=window_size(Set)
 		chr_names=chr_names(Set)
 		chr_lengths=chr_lengths(Set)
-		chromosomes=chr_names(Set)		
+		chromosomes=chr_names(Set)
 		output_data = genome_count(Set)
-		header_out=paste("track type=wiggle_0 name=\"", descr, "\" description=\"", descr, "\" visibility=full autoScale=on color=0,0,255 maxHeightPixels=100:50:20 graphType=bar priority=20", sep="")	
+		header_out=paste("track type=wiggle_0 name=\"", descr, "\" description=\"", descr, "\" visibility=full autoScale=on color=0,0,255 maxHeightPixels=100:50:20 graphType=bar priority=20", sep="")
 	}
 	else if(format=="rpkm"){
 		if(class(Set)!="MEDIPSset"){stop("For exporting rpkm data, you have to specify a MEDIPSset object at Set!")}
 		window_size=window_size(Set)
 		chr_names=chr_names(Set)
 		chr_lengths=chr_lengths(Set)
-		chromosomes=chr_names(Set)				
+		chromosomes=chr_names(Set)
 		output_data = round((genome_count(Set)*10^9)/(window_size*number_regions(Set)), digits=2)
-		header_out=paste("track type=wiggle_0 name=\"", descr, "\" description=\"", descr, "\" visibility=full autoScale=on color=0,0,255 maxHeightPixels=100:50:20 graphType=bar priority=20", sep="")	
+		header_out=paste("track type=wiggle_0 name=\"", descr, "\" description=\"", descr, "\" visibility=full autoScale=on color=0,0,255 maxHeightPixels=100:50:20 graphType=bar priority=20", sep="")
 	}
 	else if(format=="rms"){
 		if(class(Set)!="MEDIPSset"){stop("For exporting rms data, you have to specify a MEDIPSset object at Set!")}
@@ -55,23 +55,23 @@ function(Set=NULL, CSet=NULL, file=NULL, format="rpkm", descr=""){
 		output_data = MEDIPS.rms(Set, CSet, ccObj=ccObj)
                 header_out=paste("track type=wiggle_0 name=\"", descr, "\" description=\"", descr, "\" visibility=full autoScale=on color=0,0,255 maxHeightPixels=100:50:20 graphType=bar priority=20", sep="")
 	}
-	
+
 	##Calculate genomic coordinates
 	##################################
 	no_chr_windows = ceiling(chr_lengths/window_size)
-	supersize_chr = cumsum(no_chr_windows)	
+	supersize_chr = cumsum(no_chr_windows)
 	genome_chr = as.vector(seqnames(MEDIPS.GenomicCoordinates(supersize_chr, no_chr_windows, chromosomes, chr_lengths, window_size)))
-		
+
 	write.table(header_out, file=file, sep="", quote=F, row.names=F, col.names=F)
-	
+
 	for(i in 1:length(chr_names)){
-		cat(paste("Writing data for ", chr_names[i], "...\n", sep=""))
+		message(paste("Writing data for ", chr_names[i], "...\n", sep=""))
 		chr_header=paste("fixedStep chrom=", chr_names[i]," start=1 step=", window_size, " span=",  window_size, sep="")
 		write.table(chr_header, file=file, sep="", quote=F, row.names=F, col.names=F, append=T)
 		temp_data=output_data[genome_chr==chr_names[i]]
 		temp_data=temp_data[-length(temp_data)]
 		write.table(temp_data, file=file, sep="", quote=F, row.names=F, col.names=F, append=T)
 	}
-	
-	
+
+
 }

--- a/R/MEDIPS.getPositions.R
+++ b/R/MEDIPS.getPositions.R
@@ -8,38 +8,38 @@
 ##Modified:	11/10/2011
 ##Author:	Lukas Chavez, Joern Dietrich
 
-MEDIPS.getPositions <-function(BSgenome=NULL, pattern=NULL, chromosomes=NULL){	
-	
+MEDIPS.getPositions <-function(BSgenome=NULL, pattern=NULL, chromosomes=NULL){
+
 	if(is.null(pattern)){stop("Must specify a sequence pattern!")}
-	
+
 	currentchr=NULL
 	currentstart=NULL
-	
+
 	organism=ls(paste("package:", BSgenome, sep=""))
 	genomedata=get(organism)
-	
+
 	##Determine pattern positions by accessing Biostrings
 	for(chromosome in chromosomes){
-		cat(paste("Searching in", chromosome, "..."))
+		message(paste("Searching in", chromosome, "..."))
 	        {subject<-genomedata[[chromosome]]}
-		
+
 		plus_matches<-matchPattern(pattern,subject)
-		start=start(plus_matches)   
+		start=start(plus_matches)
 		currentchr=c(currentchr,rep(chromosome,length(start)))
-		currentstart=c(currentstart,start) 
+		currentstart=c(currentstart,start)
 
 		pattern<-DNAString(pattern)
 		rcpattern<-reverseComplement(pattern)
 		if(pattern!=rcpattern){
 			minus_matches<-matchPattern(rcpattern,subject)
-			start=start(minus_matches) 
+			start=start(minus_matches)
 			currentchr=c(currentchr,rep(chromosome,length(start)))
-			currentstart=c(currentstart,start) 
+			currentstart=c(currentstart,start)
 		}
-		cat(paste("[", length(start), "] found.\n"))			
+		message(paste("[", length(start), "] found.\n"))
 	}
 
-	cat(paste("Number of identified ", pattern, " pattern: ", length(currentchr), "\n"))
+	message(paste("Number of identified ", pattern, " pattern: ", length(currentchr), "\n"))
 	gc()
 	return(GRanges(seqnames=currentchr, ranges=IRanges(start=currentstart, end=currentstart)))
 }

--- a/R/MEDIPS.getPositions.R
+++ b/R/MEDIPS.getPositions.R
@@ -20,7 +20,7 @@ MEDIPS.getPositions <-function(BSgenome=NULL, pattern=NULL, chromosomes=NULL){
 
 	##Determine pattern positions by accessing Biostrings
 	for(chromosome in chromosomes){
-		message(paste("Searching in", chromosome, "..."))
+		message("Searching in ", chromosome, " ...", appendLF=T)
 	        {subject<-genomedata[[chromosome]]}
 
 		plus_matches<-matchPattern(pattern,subject)
@@ -36,10 +36,10 @@ MEDIPS.getPositions <-function(BSgenome=NULL, pattern=NULL, chromosomes=NULL){
 			currentchr=c(currentchr,rep(chromosome,length(start)))
 			currentstart=c(currentstart,start)
 		}
-		message(paste("[", length(start), "] found.\n"))
+		message("[", length(start), "] found.", appendLF=T)
 	}
 
-	message(paste("Number of identified ", pattern, " pattern: ", length(currentchr), "\n"))
+	message("Number of identified ", pattern, " pattern: ", length(currentchr), appendLF=T)
 	gc()
 	return(GRanges(seqnames=currentchr, ranges=IRanges(start=currentstart, end=currentstart)))
 }

--- a/R/MEDIPS.mergeFrames.R
+++ b/R/MEDIPS.mergeFrames.R
@@ -8,39 +8,39 @@
 ##Author:	Lukas Chavez
 
 MEDIPS.mergeFrames = function(frames=NULL, distance=1){
-	
-	if(is.null(frames)){stop("Must specify a frame set.")}	
-	
+
+	if(is.null(frames)){stop("Must specify a frame set.")}
+
 	chromosomes=as.character(unique(frames[,1]))
-	
+
 	output=NULL
-	
+
 	for(i in 1:length(chromosomes)){
 		start=as.numeric(frames[,2][as.character(frames[,1])==chromosomes[i]])
 		stop=as.numeric(frames[,3][as.character(frames[,1])==chromosomes[i]])
 		stop_ext=stop+(distance)
-			
-		start_ID=vector(length=length(start), mode="numeric") 
-		start_ID[]=1					
-			
-		stop_ID=vector(length=length(stop), mode="numeric") 
+
+		start_ID=vector(length=length(start), mode="numeric")
+		start_ID[]=1
+
+		stop_ID=vector(length=length(stop), mode="numeric")
 		stop_ID[]=-1
-			
-		positions=vector(length=(length(start)+length(stop)), mode="numeric") 
+
+		positions=vector(length=(length(start)+length(stop)), mode="numeric")
 		positions[]=append(start, stop_ext)
-		
+
 		positions_orig=vector(length=(length(start)+length(stop)), mode="numeric")
 		positions_orig[]=append(start, stop)
-		
-		IDs=vector(length=(length(start)+length(stop)), mode="numeric") 
+
+		IDs=vector(length=(length(start)+length(stop)), mode="numeric")
 		IDs[]=append(start_ID, stop_ID)
-		
+
 		IDs=IDs[order(positions)]
 		positions_orig=positions_orig[order(positions)]
 		positions=positions[order(positions)]
-		
-		merged_IDs=cumsum(IDs)		
-				
+
+		merged_IDs=cumsum(IDs)
+
 		new_stop=positions_orig[merged_IDs==0]
 		indices_stop=which(merged_IDs==0)
 
@@ -53,8 +53,7 @@ MEDIPS.mergeFrames = function(frames=NULL, distance=1){
 
 	output = cbind(output, paste("ID", seq(1, nrow(output)), sep="_"))
 
-	print(paste("Number of merged frames: ", length(output[,1]), sep=""), quote=F)
+	message(paste("Number of merged frames: ", length(output[,1]), sep=""), quote=F)
 	output=list(chr=as.character(output[,1]), start=format(as.numeric(output[,2]), scientific=F, trim=T), stop=format(as.numeric(output[,3]), scientific=F, trim=T), ID=as.character(output[,4]))
-	return(as.data.frame(output,stringsAsFactors=F))	
+	return(as.data.frame(output,stringsAsFactors=F))
 }
-

--- a/R/MEDIPS.mergeFrames.R
+++ b/R/MEDIPS.mergeFrames.R
@@ -53,7 +53,7 @@ MEDIPS.mergeFrames = function(frames=NULL, distance=1){
 
 	output = cbind(output, paste("ID", seq(1, nrow(output)), sep="_"))
 
-	message(paste("Number of merged frames: ", length(output[,1]), sep=""), quote=F)
+	message("Number of merged frames: ", length(output[,1]), appendLF=T)
 	output=list(chr=as.character(output[,1]), start=format(as.numeric(output[,2]), scientific=F, trim=T), stop=format(as.numeric(output[,3]), scientific=F, trim=T), ID=as.character(output[,4]))
 	return(as.data.frame(output,stringsAsFactors=F))
 }

--- a/R/MEDIPS.meth.R
+++ b/R/MEDIPS.meth.R
@@ -102,7 +102,7 @@ MEDIPS.meth = function(
 	##Add counts
 	if(!is.null(MSet1)){
 		for(i in 1:nMSets1){
-			message(paste("Preprocessing MEDIPS SET ", i, " in MSet1...\n", sep=""))
+			message("Preprocessing MEDIPS SET ", i, " in MSet1...", appendLF=T)
 			counts.medip = cbind(counts.medip, MSet1=genome_count(MSet1[[i]]))
 			rpkm.medip = cbind(rpkm.medip, round(((genome_count(MSet1[[i]])*10^9)/(window_size*number_regions(MSet1[[i]]))), digits=2))
 			if(MeDIP){
@@ -113,7 +113,7 @@ MEDIPS.meth = function(
 	}
 	if(!is.null(MSet2)){
 		 for(i in 1:nMSets2){
-			message(paste("Preprocessing MEDIPS SET ", i, " in MSet2...\n", sep=""))
+			message("Preprocessing MEDIPS SET ", i, " in MSet2...", appendLF=T)
 			counts.medip = cbind(counts.medip, MSet2=genome_count(MSet2[[i]]))
 			rpkm.medip = cbind(rpkm.medip, round(((genome_count(MSet2[[i]])*10^9)/(window_size*number_regions(MSet2[[i]]))), digits=2))
 			if(MeDIP){
@@ -124,14 +124,14 @@ MEDIPS.meth = function(
 	}
 	if(!is.null(ISet1)){
 		for(i in 1:nISets1){
-			message(paste("Preprocessing INPUT SET ", i, " in ISet1...\n", sep=""))
+			message("Preprocessing INPUT SET ", i, " in ISet1...", appendLF=T)
 			counts.input = cbind(counts.input, ISet1=genome_count(ISet1[[i]]))
 			rpkm.input = cbind(rpkm.input, round(((genome_count(ISet1[[i]])*10^9)/(window_size*number_regions(ISet1[[i]]))), digits=2))
 		   }
 	}
 	if(!is.null(ISet2)){
 		for(i in 1:nISets2){
-			message(paste("Preprocessing INPUT SET ", i, " in ISet2...\n", sep=""))
+			message("Preprocessing INPUT SET ", i, " in ISet2...", appendLF=T)
 			counts.input = cbind(counts.input, ISet2=genome_count(ISet2[[i]]))
 			rpkm.input = cbind(rpkm.input, round(((genome_count(ISet2[[i]])*10^9)/(window_size*number_regions(ISet2[[i]]))), digits=2))
 		 	}
@@ -142,7 +142,7 @@ MEDIPS.meth = function(
 	if(!is.null(chr)){
 		fi=base[,1]%in%chr
 
-		message("Extracting data for", chr, "...\n", sep=" ")
+		message("Extracting data for ", chr, " ...", appendLF=T)
 		if(length(fi)==0){stop("Stated chromosome does not exist in the COUPLING SET.")}
 		if(!is.null(counts.medip)){
 			counts.medip = counts.medip[fi,]
@@ -154,7 +154,7 @@ MEDIPS.meth = function(
 			rpkm.input = rpkm.input[fi,]
 		}
 		base = base[fi,]
-		message(nrow(base), "windows on", chr, "\n",sep=" ")
+		message(nrow(base), " windows on ", chr, appendLF=T)
 	}
 
 	##Set colnames and transform to data.frames
@@ -220,7 +220,7 @@ MEDIPS.meth = function(
 	##calculate differential coverage
 	##################################
 	if(!is.null(MSet1) & !is.null(MSet2)){
-		message(paste("Differential coverage analysis...\n", sep=" "))
+		message("Differential coverage analysis...", appendLF=T)
 
 		##Correct for test selection if necessary
 		if((nMSets1<3 | nMSets2<3) & diff.method=="ttest"){
@@ -249,7 +249,7 @@ MEDIPS.meth = function(
 
 			#Quantile normalization
 			if(diffnorm=="quantile"){
-				message("Performing quantile normalization on sequencing counts. Please note, the returned counts - but not the returned rpkm values - will be quantile normalized.\n")
+				message("Performing quantile normalization on sequencing counts. Please note, the returned counts - but not the returned rpkm values - will be quantile normalized.", appendLF=T)
 				counts.medip.coln = colnames(counts.medip)
 				counts.medip = preprocessCore::normalize.quantiles(as.matrix(counts.medip), copy=FALSE)
 				counts.medip <- round(counts.medip)
@@ -281,7 +281,7 @@ MEDIPS.meth = function(
 		}
 		else{stop("Selected method for calculating differential coverage not supported")}
 
-		message("Please note, log2 ratios are reported as log2(MSet1/MSet2).\n")
+		message("Please note, log2 ratios are reported as log2(MSet1/MSet2).", appendLF=T)
 		diff.results = diff.results.list$diff.results
 		diff.index = diff.results.list$diff.index
 
@@ -290,7 +290,7 @@ MEDIPS.meth = function(
 
 	}
 	else{
-		warning("No differential coverage will be calculated- only one group of MEDIPS SETs given.\n")
+		warning("No differential coverage will be calculated- only one group of MEDIPS SETs given.")
 	}
 
 	##If two groups of INPUT SETs are given
@@ -298,7 +298,7 @@ MEDIPS.meth = function(
 	##################################
 	if(CNV){
 		if(!is.null(ISet1) & !is.null(ISet2)){
-			message(paste("CNV analysis...\n", sep=" "))
+			message(paste("CNV analysis...", appendLF=T)
 			cnv.combined = MEDIPS.cnv(base=base, rpkm.input=rpkm.input, nISets1=nISets1, nISets2=nISets2)
 		}
 		else{
@@ -308,7 +308,7 @@ MEDIPS.meth = function(
 
 	##Create results table
 	##################################
-	message(paste("Creating results table...\n", sep=" "))
+	message("Creating results table...", appendLF=T)
 	if(!is.null(counts.medip)){
 		if(MeDIP){
 			results = data.frame(base, counts.medip, rpkm.medip, rms, stringsAsFactors=F)
@@ -411,7 +411,7 @@ MEDIPS.meth = function(
 
 	##Add diff.meth results
 	if(nMSets1!=0 & nMSets2!=0){
-		message(paste("Adding differential coverage results...\n", sep=" "))
+		message("Adding differential coverage results...", appendLF=T)
 		dummy.results = matrix(ncol=ncol(diff.results), nrow=nrow(results))
 
 		if(diff.method=="edgeR"){
@@ -432,7 +432,7 @@ MEDIPS.meth = function(
 	##Add CNV results
 	if(!is.null(ISet1) & !is.null(ISet2)){
 		if(CNV){
-			message(paste("Adding CNV results...\n", sep=" "))
+			message("Adding CNV results...", appendLF=T)
 			dummy.results = matrix(ncol=1, nrow=(nrow(results)))
 			for(i in 1:nrow(cnv.combined)){
 				dummy.results[cnv.combined[i,1]:cnv.combined[i,2]] = cnv.combined[i,3]

--- a/R/MEDIPS.meth.R
+++ b/R/MEDIPS.meth.R
@@ -298,7 +298,7 @@ MEDIPS.meth = function(
 	##################################
 	if(CNV){
 		if(!is.null(ISet1) & !is.null(ISet2)){
-			message(paste("CNV analysis...", appendLF=T)
+			message("CNV analysis...", appendLF=T)
 			cnv.combined = MEDIPS.cnv(base=base, rpkm.input=rpkm.input, nISets1=nISets1, nISets2=nISets2)
 		}
 		else{

--- a/R/MEDIPS.meth.R
+++ b/R/MEDIPS.meth.R
@@ -11,30 +11,30 @@
 ##Author:	Lukas Chavez
 
 MEDIPS.meth = function(
-		MSet1 = NULL, 
-		MSet2 = NULL, 
-		CSet = NULL, 
-		ISet1 = NULL, 
-		ISet2 = NULL, 
-		chr = NULL, 
-		p.adj="bonferroni", 
-		diff.method="edgeR", 
+		MSet1 = NULL,
+		MSet2 = NULL,
+		CSet = NULL,
+		ISet1 = NULL,
+		ISet2 = NULL,
+		chr = NULL,
+		p.adj="bonferroni",
+		diff.method="edgeR",
 		CNV=FALSE,
 		MeDIP=FALSE,
 		minRowSum=10,
 		diffnorm="tmm"
 		)
 {
-	nMSets1 = length(MSet1)	
-	nMSets2 = length(MSet2)	
-	nISets1 = length(ISet1)	
-	nISets2 = length(ISet2)	
+	nMSets1 = length(MSet1)
+	nMSets2 = length(MSet2)
+	nISets1 = length(ISet1)
+	nISets2 = length(ISet2)
 	if(is.list(CSet)) CSet=CSet[[1]]
 	if(!is.list(MSet1)) MSet1=c(MSet1)
 	if(!is.list(MSet2)) MSet2=c(MSet2)
 	if(!is.list(ISet1)) ISet1=c(ISet1)
 	if(!is.list(ISet2)) ISet2=c(ISet2)
-	
+
 	##Proof of correctness
 	#######################
 	if(MeDIP){
@@ -52,7 +52,7 @@ MEDIPS.meth = function(
 			if(class(MSet2[[i]])!="MEDIPSset" & class(MSet2[[i]])!="MEDIPSroiSet"){stop("You have to state a MEDIPSset or MEDIPSroiSet object!")}
 			if(length(genome_count(MSet2[[i]]))!=length(genome_count(controlSet)))stop("MEDIPSset/MEDIPSroiSet objects are of different length!")
     		}
-	}	
+	}
 	if(!is.null(ISet1)){
 		for(i in 1:nISets1){
 			if(class(ISet1[[i]])!="MEDIPSset" & class(ISet1[[i]])!="MEDIPSroiSet"){stop("You have to state a MEDIPSset or MEDIPSroiSet object!")}
@@ -74,14 +74,14 @@ MEDIPS.meth = function(
 	if(class(controlSet)=="MEDIPSset"){
 		window_size = window_size(controlSet)
 		no_chr_windows = ceiling(chr_lengths(controlSet)/window_size(controlSet))
-		supersize_chr = cumsum(no_chr_windows)	
+		supersize_chr = cumsum(no_chr_windows)
 		GRanges.genome = MEDIPS.GenomicCoordinates(supersize_chr, no_chr_windows, chr_names(controlSet), chr_lengths(controlSet), window_size(controlSet))
 	}
 	else if(class(controlSet)=="MEDIPSroiSet"){
 		GRanges.genome = rois(controlSet)
 		window_size=as.numeric(width(GRanges.genome))
-	} 
-	
+	}
+
 	##Create data frame for all genomic windows and MEDIPS SETs
 	if(MeDIP){
 		base = data.frame(chr=as.vector(seqnames(GRanges.genome)), start=start(GRanges.genome), stop=end(GRanges.genome), CF=genome_CF(CSet), stringsAsFactors=F)
@@ -95,25 +95,25 @@ MEDIPS.meth = function(
 
 	counts.medip = NULL
 	rpkm.medip = NULL
-	rms = NULL	
+	rms = NULL
 	counts.input = NULL
 	rpkm.input = NULL
-	
+
 	##Add counts
 	if(!is.null(MSet1)){
 		for(i in 1:nMSets1){
-			cat(paste("Preprocessing MEDIPS SET ", i, " in MSet1...\n", sep=""))
+			message(paste("Preprocessing MEDIPS SET ", i, " in MSet1...\n", sep=""))
 			counts.medip = cbind(counts.medip, MSet1=genome_count(MSet1[[i]]))
 			rpkm.medip = cbind(rpkm.medip, round(((genome_count(MSet1[[i]])*10^9)/(window_size*number_regions(MSet1[[i]]))), digits=2))
 			if(MeDIP){
 				ccObj = MEDIPS.calibrationCurve(MSet=MSet1[[i]], CSet=CSet, input=F)
 				rms = cbind(rms, MEDIPS.rms(MSet1[[i]], CSet, ccObj=ccObj))
-			}		
+			}
 		}
-	}	
+	}
 	if(!is.null(MSet2)){
 		 for(i in 1:nMSets2){
-			cat(paste("Preprocessing MEDIPS SET ", i, " in MSet2...\n", sep=""))
+			message(paste("Preprocessing MEDIPS SET ", i, " in MSet2...\n", sep=""))
 			counts.medip = cbind(counts.medip, MSet2=genome_count(MSet2[[i]]))
 			rpkm.medip = cbind(rpkm.medip, round(((genome_count(MSet2[[i]])*10^9)/(window_size*number_regions(MSet2[[i]]))), digits=2))
 			if(MeDIP){
@@ -121,28 +121,28 @@ MEDIPS.meth = function(
 				rms = cbind(rms, MEDIPS.rms(MSet2[[i]], CSet, ccObj=ccObj))
 			}
 	  	 }
-	}	
-	if(!is.null(ISet1)){		
+	}
+	if(!is.null(ISet1)){
 		for(i in 1:nISets1){
-			cat(paste("Preprocessing INPUT SET ", i, " in ISet1...\n", sep=""))
+			message(paste("Preprocessing INPUT SET ", i, " in ISet1...\n", sep=""))
 			counts.input = cbind(counts.input, ISet1=genome_count(ISet1[[i]]))
 			rpkm.input = cbind(rpkm.input, round(((genome_count(ISet1[[i]])*10^9)/(window_size*number_regions(ISet1[[i]]))), digits=2))
 		   }
-	}	
+	}
 	if(!is.null(ISet2)){
 		for(i in 1:nISets2){
-			cat(paste("Preprocessing INPUT SET ", i, " in ISet2...\n", sep=""))
+			message(paste("Preprocessing INPUT SET ", i, " in ISet2...\n", sep=""))
 			counts.input = cbind(counts.input, ISet2=genome_count(ISet2[[i]]))
 			rpkm.input = cbind(rpkm.input, round(((genome_count(ISet2[[i]])*10^9)/(window_size*number_regions(ISet2[[i]]))), digits=2))
 		 	}
-	}		
-	
+	}
+
 	##Extract data for selected chromosome
 	#######################################
 	if(!is.null(chr)){
 		fi=base[,1]%in%chr
-		
-		cat("Extracting data for", chr, "...\n", sep=" ")
+
+		message("Extracting data for", chr, "...\n", sep=" ")
 		if(length(fi)==0){stop("Stated chromosome does not exist in the COUPLING SET.")}
 		if(!is.null(counts.medip)){
 			counts.medip = counts.medip[fi,]
@@ -154,9 +154,9 @@ MEDIPS.meth = function(
 			rpkm.input = rpkm.input[fi,]
 		}
 		base = base[fi,]
-		cat(nrow(base), "windows on", chr, "\n",sep=" ")		
+		message(nrow(base), "windows on", chr, "\n",sep=" ")
 	}
-	
+
 	##Set colnames and transform to data.frames
 	############################################
 	col.names.count = NULL
@@ -169,7 +169,7 @@ MEDIPS.meth = function(
 			if(MeDIP){
 				col.names.rms = c(col.names.rms, paste(sample_name(MSet1[[i]]), ".rms", sep=""))
 			}
-		}		
+		}
 	}
 	if(nMSets2!=0){
 		for(i in 1:nMSets2){
@@ -178,10 +178,10 @@ MEDIPS.meth = function(
 			if(MeDIP){
 				col.names.rms = c(col.names.rms, paste(sample_name(MSet2[[i]]), ".rms", sep=""))
 			}
-		}		
+		}
 	}
 	if(nMSets1!=0 | nMSets2!=0){
-		
+
 		counts.medip = data.frame(counts.medip)
 		colnames(counts.medip) = col.names.count
 		rpkm.medip =  data.frame(rpkm.medip)
@@ -190,72 +190,72 @@ MEDIPS.meth = function(
 			rms = data.frame(rms)
 			colnames(rms) = col.names.rms
 		}
-	}		
-	
+	}
+
 	col.names.count.input = NULL
 	col.names.rpkm.input = NULL
 	if(nISets1!=0){
 		for(i in 1:nISets1){
 			col.names.count.input = c(col.names.count.input, paste(sample_name(ISet1[[i]]), ".counts", sep=""))
 			col.names.rpkm.input = c(col.names.rpkm.input, paste(sample_name(ISet1[[i]]), ".rpkm", sep=""))
-		}		
+		}
 	}
 	if(nISets2!=0){
 		for(i in 1:nISets2){
 			col.names.count.input = c(col.names.count.input, paste(sample_name(ISet2[[i]]), ".counts", sep=""))
 			col.names.rpkm.input = c(col.names.rpkm.input, paste(sample_name(ISet2[[i]]), ".rpkm", sep=""))
-		}		
+		}
 	}
-	
-	if(nISets1!=0 | nISets2!=0){		
-		
+
+	if(nISets1!=0 | nISets2!=0){
+
 		counts.input = data.frame(counts.input)
 		colnames(counts.input) = 	col.names.count.input
-		rpkm.input = data.frame(rpkm.input)	
+		rpkm.input = data.frame(rpkm.input)
 		colnames(rpkm.input) = 		col.names.rpkm.input
 	}
-		
-	
-	##If two groups of MEDIPS SETs are given 
+
+
+	##If two groups of MEDIPS SETs are given
 	##calculate differential coverage
 	##################################
 	if(!is.null(MSet1) & !is.null(MSet2)){
-		cat(paste("Differential coverage analysis...\n", sep=" "))
-		
+		message(paste("Differential coverage analysis...\n", sep=" "))
+
 		##Correct for test selection if necessary
 		if((nMSets1<3 | nMSets2<3) & diff.method=="ttest"){
 			stop("Method 'ttest' is not valid for less than 3 replicates per group. Method 'edgeR' can be applied in this case.")
-		}		
-		
+		}
+
 		if(diff.method=="edgeR"){
-			
+
 			if(diffnorm=="rpkm" | diffnorm=="rms"){
 				stop("rpkm and rms normalization are not available for the edgeR mode. Here, differential enrichment is performed on the count data. Please set diffnorm to tmm or quantile.\n")
 			}
-			
+
 			##Extract number of reads per sample
 			if(!is.null(MSet1)){
 				n.r.M1 = NULL
 				for(i in 1:nMSets1){
-					n.r.M1 = c(n.r.M1, number_regions(MSet1[[i]]))		
+					n.r.M1 = c(n.r.M1, number_regions(MSet1[[i]]))
 				}
-			}	
+			}
 			if(!is.null(MSet2)){
 		 		n.r.M2 = NULL
 		 		for(i in 1:nMSets2){
-					n.r.M2 = c(n.r.M2, number_regions(MSet2[[i]]))	
+					n.r.M2 = c(n.r.M2, number_regions(MSet2[[i]]))
 	  	 		}
-			}	
+			}
 
 			#Quantile normalization
 			if(diffnorm=="quantile"){
-				cat("Performing quantile normalization on sequencing counts. Please note, the returned counts - but not the returned rpkm values - will be quantile normalized.\n")
-				counts.medip.coln = colnames(counts.medip)				
-				counts.medip = preprocessCore::normalize.quantiles(as.matrix(counts.medip), copy=FALSE)	
+				message("Performing quantile normalization on sequencing counts. Please note, the returned counts - but not the returned rpkm values - will be quantile normalized.\n")
+				counts.medip.coln = colnames(counts.medip)
+				counts.medip = preprocessCore::normalize.quantiles(as.matrix(counts.medip), copy=FALSE)
 				counts.medip <- round(counts.medip)
 				colnames(counts.medip) = counts.medip.coln
 			}
-		
+
 			diff.results.list = MEDIPS.diffMeth(base=base, values=counts.medip, diff.method="edgeR", nMSets1=nMSets1, nMSets2=nMSets2, p.adj=p.adj, n.r.M1=n.r.M1, n.r.M2=n.r.M2, MeDIP=MeDIP, minRowSum=minRowSum, diffnorm=diffnorm)
 		}
 		else if(diff.method=="ttest"){
@@ -280,35 +280,35 @@ MEDIPS.meth = function(
 			}
 		}
 		else{stop("Selected method for calculating differential coverage not supported")}
-		
-		cat("Please note, log2 ratios are reported as log2(MSet1/MSet2).\n")
+
+		message("Please note, log2 ratios are reported as log2(MSet1/MSet2).\n")
 		diff.results = diff.results.list$diff.results
 		diff.index = diff.results.list$diff.index
-				
+
 		rm(diff.results.list)
 		gc()
-	
+
 	}
 	else{
-		cat("No differential coverage will be calculated- only one group of MEDIPS SETs given.\n")
+		warning("No differential coverage will be calculated- only one group of MEDIPS SETs given.\n")
 	}
-	
-	##If two groups of INPUT SETs are given 
+
+	##If two groups of INPUT SETs are given
 	##calculate CNV on mean per set
 	##################################
 	if(CNV){
 		if(!is.null(ISet1) & !is.null(ISet2)){
-			cat(paste("CNV analysis...\n", sep=" "))		
+			message(paste("CNV analysis...\n", sep=" "))
 			cnv.combined = MEDIPS.cnv(base=base, rpkm.input=rpkm.input, nISets1=nISets1, nISets2=nISets2)
 		}
 		else{
-			cat("Cannot perform CNV analysis- please specify two groups of INPUT SETs!\n")
+			warning("Cannot perform CNV analysis- please specify two groups of INPUT SETs!\n")
 		}
 	}
-	
-	##Create results table	
+
+	##Create results table
 	##################################
-	cat(paste("Creating results table...\n", sep=" "))
+	message(paste("Creating results table...\n", sep=" "))
 	if(!is.null(counts.medip)){
 		if(MeDIP){
 			results = data.frame(base, counts.medip, rpkm.medip, rms, stringsAsFactors=F)
@@ -326,7 +326,7 @@ MEDIPS.meth = function(
 			results = data.frame(base, counts.input, rpkm.input, stringsAsFactors=F)
 		}
 	}
-	
+
 	##Add mean counts, rpkm, rms columns
 	set1idx=1:(nMSets1)
 	counts.mean.C=numeric(dim(counts.medip)[1])
@@ -358,7 +358,7 @@ MEDIPS.meth = function(
 		for (i in set2idx){
 			counts.mean.T=counts.mean.T+counts.medip[,i]
 			rpkm.mean.T=rpkm.mean.T+rpkm.medip[,i]
-		}	
+		}
 		counts.mean.T=counts.mean.T/nMSets2
 		rpkm.mean.T=rpkm.mean.T/nMSets2
 
@@ -404,50 +404,49 @@ MEDIPS.meth = function(
 		results = data.frame(results, ISets2.counts.mean=counts.input.mean.T, ISets2.rpkm.mean=rpkm.input.mean.T, stringsAsFactors=F)
 		rm(counts.input.mean.T,rpkm.input.mean.T,setI2idx)
 	}
-	
+
 	if(MeDIP){rm(base, counts.medip, rpkm.medip, rms, counts.input, rpkm.input)}
 	else{rm(base, counts.medip, rpkm.medip, counts.input, rpkm.input)}
 	gc()
-	
+
 	##Add diff.meth results
 	if(nMSets1!=0 & nMSets2!=0){
-		cat(paste("Adding differential coverage results...\n", sep=" "))
+		message(paste("Adding differential coverage results...\n", sep=" "))
 		dummy.results = matrix(ncol=ncol(diff.results), nrow=nrow(results))
-		
+
 		if(diff.method=="edgeR"){
 			c.names = colnames(diff.results)
 			diff.results <- matrix(unlist(diff.results), ncol=ncol(diff.results), byrow=FALSE)
 			colnames(diff.results)=c.names
 			rm(c.names)
 		}
-		
+
 		dummy.results[diff.index,] = diff.results
-		colnames(dummy.results)=colnames(diff.results)		
+		colnames(dummy.results)=colnames(diff.results)
 		results = data.frame(results, dummy.results, stringsAsFactors=F)
-			
+
 		rm(diff.results, dummy.results, diff.index)
 		gc()
 	}
-	
+
 	##Add CNV results
 	if(!is.null(ISet1) & !is.null(ISet2)){
 		if(CNV){
-			cat(paste("Adding CNV results...\n", sep=" "))
+			message(paste("Adding CNV results...\n", sep=" "))
 			dummy.results = matrix(ncol=1, nrow=(nrow(results)))
 			for(i in 1:nrow(cnv.combined)){
-				dummy.results[cnv.combined[i,1]:cnv.combined[i,2]] = cnv.combined[i,3]		
+				dummy.results[cnv.combined[i,1]:cnv.combined[i,2]] = cnv.combined[i,3]
 			}
 		colnames(dummy.results)="CNV.log2.ratio"
 		results = data.frame(results, dummy.results, stringsAsFactors=F)
-		
-		rm(dummy.results)	
+
+		rm(dummy.results)
 		gc()
 		}
 	}
-	
+
 	rownames(results) = seq(1, nrow(results))
     	gc()
 	return(results)
-		
-}
 
+}

--- a/R/MEDIPS.plotCalibrationPlot.R
+++ b/R/MEDIPS.plotCalibrationPlot.R
@@ -8,18 +8,18 @@
 ##Author:	Lukas Chavez, Matthias Lienhard
 
 MEDIPS.plotCalibrationPlot <- function(MSet=NULL, ISet=NULL, CSet=NULL, plot_chr="all", rpkm=T, main="Calibration plot", xrange=T){
-	
+
 	##Proof data accordance....
 	##########################
 	input=F
 
-	if(!(is.null(MSet)) & (class(MSet)!="MEDIPSset" & class(MSet)!="MEDIPSroiSet")) stop("MSet must be a MEDIPSset or MEDIPSroiSet object!")	
-	if(!(is.null(ISet)) & (class(ISet)!="MEDIPSset" & class(ISet)!="MEDIPSroiSet")) stop("ISet must be a MEDIPSset or MEDIPSroiSet object!")	
-	if(is.null(MSet) & is.null(ISet) ) stop("ISet and/or MSet must be specified")	
+	if(!(is.null(MSet)) & (class(MSet)!="MEDIPSset" & class(MSet)!="MEDIPSroiSet")) stop("MSet must be a MEDIPSset or MEDIPSroiSet object!")
+	if(!(is.null(ISet)) & (class(ISet)!="MEDIPSset" & class(ISet)!="MEDIPSroiSet")) stop("ISet must be a MEDIPSset or MEDIPSroiSet object!")
+	if(is.null(MSet) & is.null(ISet) ) stop("ISet and/or MSet must be specified")
 
 	#print("Checking CSet")
 	if(class(CSet)!="COUPLINGset") stop("Must specify a COUPLINGset object!")
-	
+
 	#print("Checking MSet")
 	if(!is.null(MSet) & class(MSet)=="MEDIPSset"){
 	  if(window_size(MSet)!=window_size(CSet)) stop("MSet and COUPLINGset have different window sizes!")
@@ -28,7 +28,7 @@ MEDIPS.plotCalibrationPlot <- function(MSet=NULL, ISet=NULL, CSet=NULL, plot_chr
 		if(chr_names(MSet)[i]!=chr_names(CSet)[i]){stop("MSset and COUPLINGset contain different chomosomes!")}
 	  }
 	}
-	
+
 	if(!is.null(MSet) & class(MSet)=="MEDIPSroiSet"){
 		if( length(genome_count(MSet)) != length(genome_CF(CSet)) ){stop("MSet and COUPLINGset have different number of regions of interest!")}
 		if( length(chr_names(MSet)) != length(chr_names(CSet)) ){stop("MSet and COUPLINGset contain a different number of chromosomes!")}
@@ -71,7 +71,7 @@ MEDIPS.plotCalibrationPlot <- function(MSet=NULL, ISet=NULL, CSet=NULL, plot_chr
 	}
 	coupling=genome_CF(CSet)
 	seq_pattern=seq_pattern(CSet)
-		
+
 	##Calculate calibration curve
 	#####################################
 	if (!is.null(MSet))
@@ -79,27 +79,27 @@ MEDIPS.plotCalibrationPlot <- function(MSet=NULL, ISet=NULL, CSet=NULL, plot_chr
 	if (!is.null(ISet))
 		ccObj_ISet = MEDIPS.calibrationCurve(MSet=ISet, CSet=CSet, input=T)
 
-		
+
 	##Check, if a subset of chromosomes has been selected
 	######################################################
 	if(plot_chr!="all" & (class(MSet)=="MEDIPSset" | class(ISet)=="MEDIPSset")){
-		cat(paste("Extracting data for",plot_chr, "...\n", sep=" "))
-		
+		message(paste("Extracting data for",plot_chr, "...\n", sep=" "))
+
 		##Calculate genomic coordinates
 		##################################
 		no_chr_windows = ceiling(chr_lengths/window_size)
-		supersize_chr = cumsum(no_chr_windows)	
+		supersize_chr = cumsum(no_chr_windows)
 		genome_chr = as.vector(seqnames(MEDIPS.GenomicCoordinates(supersize_chr, no_chr_windows, chromosomes, chr_lengths, window_size)))
-				
+
 		if(length(genome_chr[genome_chr==plot_chr])==0){stop("Stated calibration chromosome does not exist within the MEDIPS SET.")}
 		signal = signal[genome_chr==plot_chr]
 		coupling = coupling[genome_chr==plot_chr]
-		cat(paste("Plotting calibration plot for", plot_chr, "...\n", sep=" "))
+		message(paste("Plotting calibration plot for", plot_chr, "...\n", sep=" "))
 	}
 
 	if(plot_chr!="all" & (class(MSet)=="MEDIPSroiSet" | class(ISet)=="MEDIPSroiSet")){stop("Selecting chromosomes nor supported for regions of interest.")}
 
-	if(plot_chr=="all"){cat("Plotting calibration plot for all chromosomes. It is recommended to redirect the output to a graphic device.\n")}
+	if(plot_chr=="all"){message("Plotting calibration plot for all chromosomes. It is recommended to redirect the output to a graphic device.\n")}
 
 	if (!rpkm) {
         	descSignal = "#reads/window"
@@ -130,10 +130,10 @@ MEDIPS.plotCalibrationPlot <- function(MSet=NULL, ISet=NULL, CSet=NULL, plot_chr
 	    range=c(0,max(ccObj_ISet$mean_signal)*5)
 	}else
 	  range=c(0,max(signal))
-	  
+
 	##Plot
 	#######
-	plot(coupling,signal, pch=".", main=main, ylab=descSignal,ylim=range, xlab=paste(seq_pattern, " coupling factor", sep=""), col="lightblue")		
+	plot(coupling,signal, pch=".", main=main, ylab=descSignal,ylim=range, xlab=paste(seq_pattern, " coupling factor", sep=""), col="lightblue")
 	for(i in 0:max(coupling)){
 	  t=table(signal[coupling==i])
 	  points(x=rep(i,length(t)), y=as.numeric(names(t)),lwd=log(t, 10), pch=4, col="lightblue")
@@ -156,5 +156,5 @@ MEDIPS.plotCalibrationPlot <- function(MSet=NULL, ISet=NULL, CSet=NULL, plot_chr
 	}
 
 	legend("topright", legend=llab, fill=lcol)
-	
+
 }

--- a/R/MEDIPS.plotCalibrationPlot.R
+++ b/R/MEDIPS.plotCalibrationPlot.R
@@ -83,7 +83,7 @@ MEDIPS.plotCalibrationPlot <- function(MSet=NULL, ISet=NULL, CSet=NULL, plot_chr
 	##Check, if a subset of chromosomes has been selected
 	######################################################
 	if(plot_chr!="all" & (class(MSet)=="MEDIPSset" | class(ISet)=="MEDIPSset")){
-		message(paste("Extracting data for",plot_chr, "...\n", sep=" "))
+		message("Extracting data for ", plot_chr, " ...", appendLF=T)
 
 		##Calculate genomic coordinates
 		##################################
@@ -94,12 +94,12 @@ MEDIPS.plotCalibrationPlot <- function(MSet=NULL, ISet=NULL, CSet=NULL, plot_chr
 		if(length(genome_chr[genome_chr==plot_chr])==0){stop("Stated calibration chromosome does not exist within the MEDIPS SET.")}
 		signal = signal[genome_chr==plot_chr]
 		coupling = coupling[genome_chr==plot_chr]
-		message(paste("Plotting calibration plot for", plot_chr, "...\n", sep=" "))
+		message("Plotting calibration plot for ", plot_chr, " ...", appendLF=T)
 	}
 
 	if(plot_chr!="all" & (class(MSet)=="MEDIPSroiSet" | class(ISet)=="MEDIPSroiSet")){stop("Selecting chromosomes nor supported for regions of interest.")}
 
-	if(plot_chr=="all"){message("Plotting calibration plot for all chromosomes. It is recommended to redirect the output to a graphic device.\n")}
+	if(plot_chr=="all"){message("Plotting calibration plot for all chromosomes. It is recommended to redirect the output to a graphic device.", appendLF=T)}
 
 	if (!rpkm) {
         	descSignal = "#reads/window"

--- a/R/MEDIPS.plotSeqCoverage.R
+++ b/R/MEDIPS.plotSeqCoverage.R
@@ -24,7 +24,7 @@ function(seqCoverageObj=NULL, main=NULL, type="pie", cov.level = c(0,1,2,3,4,5),
 
 	if(type=="pie"){
 
-		message("Creating summary...\n")
+		message("Creating summary...", appendLF=T)
 		results = NULL
 		for(i in 1:length(cov.level)){
 			if(i==1){

--- a/R/MEDIPS.plotSeqCoverage.R
+++ b/R/MEDIPS.plotSeqCoverage.R
@@ -9,22 +9,22 @@
 
 MEDIPS.plotSeqCoverage <-
 function(seqCoverageObj=NULL, main=NULL, type="pie", cov.level = c(0,1,2,3,4,5), t="Inf"){
-	
+
 	if(is.null(seqCoverageObj)){stop("Must specify a coverage object.")}
 
 	cov.res=	seqCoverageObj$cov.res
-	numberPos=	length(cov.res)	
+	numberPos=	length(cov.res)
 	pattern=	seqCoverageObj$pattern
 	numberReads=	seqCoverageObj$numberReads
 	numberReadsWO=	seqCoverageObj$numberReadsWO
-	
+
 	if(is.null(main)){main = paste("Total number of ", pattern, "'s: ", numberPos, sep="") }
-	
+
 	sub = paste(numberReadsWO, " of ", numberReads, " reads (", round((numberReadsWO/numberReads*100), digits=2) , "%) do not cover a pattern", sep="")
- 	
+
 	if(type=="pie"){
-	
-		cat("Creating summary...\n")
+
+		message("Creating summary...\n")
 		results = NULL
 		for(i in 1:length(cov.level)){
 			if(i==1){
@@ -34,8 +34,8 @@ function(seqCoverageObj=NULL, main=NULL, type="pie", cov.level = c(0,1,2,3,4,5),
 				results = c(results, length(cov.res[cov.res>cov.level[i-1] & cov.res<=cov.level[i]]))
 			}
 		}
-		results = c(results, length(cov.res[cov.res>cov.level[length(cov.level)]]))	
-		
+		results = c(results, length(cov.res[cov.res>cov.level[length(cov.level)]]))
+
 		#Set the labels for the output plot
 		labels = NULL
 		for(i in 1:length(cov.level)){
@@ -47,11 +47,11 @@ function(seqCoverageObj=NULL, main=NULL, type="pie", cov.level = c(0,1,2,3,4,5),
 		 	}
 		}
 		labels = c(labels, paste(">", cov.level[length(cov.level)], "x (", round((results[length(results)]/numberPos)*100, digits=2), "%)", sep=""))
-			
-	
+
+
 		#Set the colors for the output plot
 		col = NULL
-		for(i in 1:(length(cov.level))){	
+		for(i in 1:(length(cov.level))){
 			if(i==1){col="red"}
 			if(i==2){col=c(col,"green")}
 			if(i==3){col=c(col,"blue")}
@@ -59,21 +59,21 @@ function(seqCoverageObj=NULL, main=NULL, type="pie", cov.level = c(0,1,2,3,4,5),
 			if(i==5){col=c(col,"brown")}
 			if(i>5){col=c(col,"darkgrey")}
 		}
-		##Plot	
+		##Plot
 		pie(
-			results, 
-			labels=labels, 
-			col=col, 
+			results,
+			labels=labels,
+			col=col,
 			main=main,
 			sub=sub
 		)
 	}
 	else if(type=="hist"){
-		hist(cov.res[cov.res<=t], 
+		hist(cov.res[cov.res<=t],
 			main=main,
 			sub=sub
 		)
 	}
 	else{stop("Plot type not supported.")}
-	
+
 }

--- a/R/MEDIPS.readRegionsFile.R
+++ b/R/MEDIPS.readRegionsFile.R
@@ -20,7 +20,7 @@ function (fileName, path = NULL, extend, shift, chr.select = NULL,
         scanFlag = scanBamFlag(isUnmappedQuery = FALSE, isSecondaryAlignment = isSecondaryAlignment)
         if (bamindex & (!is.null(chr.select) | !is.null(ROI))) {
             if (!is.null(ROI)) {
-                message("Reading bam alignment", fileName, "\n considering ROIs using bam index\n")
+                message("Reading bam alignment ", fileName, "\n considering ROIs using bam index", appendLF=T)
                 if (!is.null(extend)) {
                   ROI[, 2] = ROI[, 2] - extend
                   ROI[, 3] = ROI[, 3] + extend
@@ -32,15 +32,15 @@ function (fileName, path = NULL, extend, shift, chr.select = NULL,
                 sel = GRanges(chr.select, IRanges(1, 536870912))
             }
             else {
-                message("Reading bam alignment", fileName, "\n considering ",
-                  chr.select, " using bam index\n")
+                message("Reading bam alignment ", fileName, "\n considering ",
+                  paste(chr.select, collapse="\t"), " using bam index", appendLF=T)
                 sel = GRanges(chr.select, IRanges(1, 536870912))
             }
             scanParam = ScanBamParam(flag = scanFlag, simpleCigar= simpleCigar, what = c("rname",
                 "pos", "strand", "qwidth", "isize", "mpos"), which = sel)
         }
         else {
-            message("Reading bam alignment", fileName, "\n")
+            message("Reading bam alignment ", fileName, appendLF=T)
             scanParam = ScanBamParam(flag = scanFlag, simpleCigar= simpleCigar, what = c("rname",
                 "pos", "strand", "qwidth", "isize", "mpos"))
         }
@@ -54,7 +54,7 @@ function (fileName, path = NULL, extend, shift, chr.select = NULL,
             stringsAsFactors = F)
     }
     else {
-        message("Reading bed alignment", fileName, "\n")
+        message("Reading bed alignment ", fileName, appendLF=T)
         regions = read.table(paste(path, fileName, sep = "/"),
             sep = "\t", header = FALSE, row.names = NULL, comment.char = "",
             colClasses = c("character", "numeric", "numeric",
@@ -62,37 +62,34 @@ function (fileName, path = NULL, extend, shift, chr.select = NULL,
         names(regions) = c("chr", "start", "stop", "strand")
     }
     if (!is.null(chr.select) & !bamindex) {
-        message("Selecting ", chr.select, "\n")
+        message("Selecting ", paste(chr.select, collapse="\t"), appendLF=T)
         regions = regions[regions[, 1] %in% as.vector(chr.select),
             ]
     }
-    message("Total number of imported short reads: ", nrow(regions),
-        "\n", sep = "")
+    message("Total number of imported short reads: ", nrow(regions), appendLF=T)
     regions = adjustReads(regions, extend, shift)
-    message("Creating GRange Object...\n")
+    message("Creating GRange Object...", appendLF=T)
     regions_GRange = GRanges(seqnames = regions$chr, ranges = IRanges(start = regions$start,
         end = regions$stop), strand = regions$strand)
 
     if(is.logical(uniq)){stop("Parameter 'uniq' is not logical anymore, please specify a p-value and see the MEDIPS vignette.")}
     if (uniq == 1) {
-		message("Keep at most one 1 read mapping to the same genomic location.\n", sep = "")
+		message("Keep at most one 1 read mapping to the same genomic location.", appendLF=T)
 		regions_GRange = unique(regions_GRange)
-		message("Number of remaining reads: ", length(regions_GRange),
-			"\n", sep = "")
+		message("Number of remaining reads: ", length(regions_GRange), appendLF=T)
 	} else if (uniq < 1 & uniq > 0) {
 		max_dup_number = qpois(1 - as.numeric(uniq), length(regions_GRange) /
 			sum(as.numeric(seqlengths(dataset)[chr.select])))
 		max_dup_number = max(1, max_dup_number)
 		message("Keep at most ", max_dup_number,
-			" read(s) mapping to the same genomic location\n", sep = "")
+			" read(s) mapping to the same genomic location", appendLF=T)
 		uniq_regions = unique(regions_GRange)
 		dup_number = countMatches(uniq_regions, regions_GRange)
 		dup_number[dup_number > max_dup_number] = max_dup_number
 		regions_GRange = rep(uniq_regions, times = dup_number)
-		message("Number of remaining reads: ", length(regions_GRange),
-			"\n", sep = "")
+		message("Number of remaining reads: ", length(regions_GRange), appendLF=T)
 	} else if (uniq == 0) {
-		message("Do not correct for potential PCR artefacts (keep all reads).\n", sep = "")
+		message("Do not correct for potential PCR artefacts (keep all reads).", appendLF=T)
 	} else {
 		stop("Must specify a valid value for parameter uniq. Please check MEDIPS vignette.")
 	}
@@ -114,7 +111,7 @@ function (fileName, path = NULL, extend, shift, chr.select = NULL,
             isSecondMateRead = F, isSecondaryAlignment = isSecondaryAlignment)
         if (bamindex & (!is.null(chr.select) | !is.null(ROI))) {
             if (!is.null(ROI)) {
-                message("Reading bam alignment", fileName, "\n considering ROIs using bam index\n")
+                message("Reading bam alignment ", fileName, "\n considering ROIs using bam index", appendLF=T)
                 if (!is.null(extend)) {
                   ROI[, 2] = ROI[, 2] - extend
                   ROI[, 3] = ROI[, 3] + extend
@@ -128,14 +125,14 @@ function (fileName, path = NULL, extend, shift, chr.select = NULL,
             }
             else {
                 message("Reading bam alignment", fileName, "\n considering ",
-                  chr.select, " using bam index\n")
+                  paste(chr.select, collapse="\t"), " using bam index", appendLF=T)
                 sel = GRanges(chr.select, IRanges(1, 536870912))
             }
         scanParam = ScanBamParam(flag = scanFlag, simpleCigar= simpleCigar, what = c("rname",
 		    "pos", "strand", "qwidth", "isize", "mpos"), which = sel)
         }
         else {
-            message("Reading bam alignment", fileName, "\n")
+            message("Reading bam alignment ", fileName, appendLF="TRUE")
             scanParam = ScanBamParam(flag = scanFlag, simpleCigar = simpleCigar, what = c("rname",
                   "pos", "strand", "qwidth", "isize", "mpos"))
         }
@@ -149,23 +146,23 @@ function (fileName, path = NULL, extend, shift, chr.select = NULL,
         stop("BED files in paired end mode not supported.\n")
     }
     if (!is.null(chr.select) & !bamindex) {
-        message("Selecting", chr.select, "\n")
+        message("Selecting", paste(chr.select, collapse="\t"), appendLF=T)
         regions = regions[regions[, 1] %in% as.vector(chr.select),
             ]
     }
     message("Total number of imported first mate reads in properly mapped pairs: ",
-        nrow(regions), "\n", sep = "")
+        nrow(regions), appendLF=T)
     message("scanBamFlag: isPaired = T, isProperPair=TRUE , hasUnmappedMate=FALSE, ",
-        "isUnmappedQuery = F, isFirstMateRead = T, isSecondMateRead = F\n",
-        sep = "")
-    message("Mean insertion size: ", mean(abs(regions$isize)), " nt\n",
-        sep = "")
+        "isUnmappedQuery = F, isFirstMateRead = T, isSecondMateRead = F",
+        appendLF=T)
+    message("Mean insertion size: ", mean(abs(regions$isize)), " nt",
+        appendLF=T)
     message("SD of the insertion size: ", sd(abs(regions$isize)),
-        " nt\n", sep = "")
-    message("Max insertion size: ", max(abs(regions$isize)), " nt\n",
-        sep = "")
-    message("Min insertion size: ", min(abs(regions$isize)), " nt\n",
-        sep = "")
+        " nt", appendLF=T)
+    message("Max insertion size: ", max(abs(regions$isize)), " nt",
+        appendLF=T)
+    message("Min insertion size: ", min(abs(regions$isize)), " nt",
+        appendLF=T)
 
    qwidth = regions[, "qwidth"]
    regions = data.frame(chr = as.character(as.vector(regions$rname)),
@@ -180,31 +177,31 @@ function (fileName, path = NULL, extend, shift, chr.select = NULL,
    if(extend!=0){warning("The extend parameter will be neglected, because the actual DNA fragment length is known in paired-end data.\n")}
    if(shift!=0){warning("The shift parameter will be neglected, because the actual DNA fragment position is known in paired-end data.\n")}
 
-    message("Creating GRange Object...\n")
+    message("Creating GRange Object...", appendLF=T)
     regions_GRange = GRanges(seqnames = regions$chr, ranges = IRanges(start = regions$start,
         end = regions$stop), strand = regions$strand)
 
 	if(is.logical(uniq)){stop("Parameter 'uniq' is not logical anymore, please specify a p-value and see the MEDIPS vignette.")}
 
 	if (uniq == 1) {
-		message("Keep at most 1 read mapping to the same genomic location.\n", sep = "")
+		message("Keep at most 1 read mapping to the same genomic location.", appendLF=T)
 		regions_GRange = unique(regions_GRange)
 		message("Number of remaining short reads: ", length(regions_GRange),
-			"\n", sep = "")
+			appendLF=T)
 	} else if (uniq < 1 & uniq > 0) {
 		max_dup_number = qpois(1 - as.numeric(uniq), length(regions_GRange) /
 			sum(as.numeric(seqlengths(dataset)[chr.select])))
 		max_dup_number = max(1, max_dup_number)
 		message("Keep at most ", max_dup_number,
-			" first mate read(s) mapping to the same genomic location\n", sep = "")
+			" first mate read(s) mapping to the same genomic location", appendLF=T)
 		uniq_regions = unique(regions_GRange)
 		dup_number = countMatches(uniq_regions, regions_GRange)
 		dup_number[dup_number > max_dup_number] = max_dup_number
 		regions_GRange = rep(uniq_regions, times = dup_number)
 		message("Number of remaining short reads: ", length(regions_GRange),
-			"\n", sep = "")
+			appendLF=T)
 	} else if (uniq == 0) {
-		message("Do not correct for potential PCR artefacts (keep all reads).\n", sep = "")
+		message("Do not correct for potential PCR artefacts (keep all reads).", appendLF=T)
 	} else {
 		stop("Must specify a valid value for parameter uniq. Please check MEDIPS vignette.")
 	}
@@ -231,9 +228,9 @@ scanBamToGRanges <- function(...) {
 ##Modified:	29/10/2012
 ##Author:	Matthias Lienhard
 getMObjectFromWIG <- function(fileName, path, chr.select=NULL,BSgenome){
-        message("Reading wiggle file",fileName,"\n")
+        message("Reading wiggle file ", fileName, appendLF=T)
 	if(!is.null(chr.select)){
-          message("Select chromosomes",chr.select,"\n")
+          message("Select chromosomes ", paste(chr.select, collapse="\t"), appendLF=T)
           sel=GRanges(chr.select,IRanges(1, 536870912))
 	  #this function will warn, if type is not bigwig
 	  wiggle=rtracklayer::import(paste(path,fileName,sep="/"), which=sel)
@@ -314,14 +311,14 @@ setTypes<-function(types){
 ##Author:	Lukas Chavez, Joern Dietrich
 adjustReads<-function(regions, extend, shift){
 	if(extend!=0){
-		message("Extending reads...\n")
+		message("Extending reads...", appendLF=T)
 		extend.c = pmax(0,extend-regions$stop+regions$start)
 		regions$stop[regions$strand=="+"]=regions$stop[regions$strand=="+"]+extend.c[regions$strand=="+"]
 		regions$start[regions$strand=="-"]=regions$start[regions$strand=="-"]-extend.c[regions$strand=="-"]
 	}
 
 	if(shift!=0){
-		message("Shifting reads...\n")
+		message("Shifting reads...", appendLF=T)
 		regions$start[regions$strand=="+"] = regions$start[regions$strand=="+"]+shift
 		regions$stop[regions$strand=="+"] = regions$stop[regions$strand=="+"]+shift
 		regions$start[regions$strand=="-"] = regions$start[regions$strand=="-"]-shift

--- a/R/MEDIPS.readRegionsFile.R
+++ b/R/MEDIPS.readRegionsFile.R
@@ -6,21 +6,21 @@
 ##Output:	Granges object
 ##Requires:	GenomicRanges
 ##Modified:	06/24/2016
-##Author:	Lukas Chavez, Joern Dietrich, Isaac Lopez Moyado 
+##Author:	Lukas Chavez, Joern Dietrich, Isaac Lopez Moyado
 
 getGRange <-
-function (fileName, path = NULL, extend, shift, chr.select = NULL, 
-    dataset = NULL, uniq = 1e-3, ROI = NULL, isSecondaryAlignment = FALSE, simpleCigar=TRUE) 
+function (fileName, path = NULL, extend, shift, chr.select = NULL,
+    dataset = NULL, uniq = 1e-3, ROI = NULL, isSecondaryAlignment = FALSE, simpleCigar=TRUE)
 {
     ext = substr(fileName, nchar(fileName) - 3, nchar(fileName))
     bam = (ext == ".bam" | ext == ".BAM")
-    bamindex = bam & file.exists(paste(path, "/", fileName, ".bai", 
+    bamindex = bam & file.exists(paste(path, "/", fileName, ".bai",
         sep = ""))
     if (bam) {
         scanFlag = scanBamFlag(isUnmappedQuery = FALSE, isSecondaryAlignment = isSecondaryAlignment)
         if (bamindex & (!is.null(chr.select) | !is.null(ROI))) {
             if (!is.null(ROI)) {
-                cat("Reading bam alignment", fileName, "\n considering ROIs using bam index\n")
+                message("Reading bam alignment", fileName, "\n considering ROIs using bam index\n")
                 if (!is.null(extend)) {
                   ROI[, 2] = ROI[, 2] - extend
                   ROI[, 3] = ROI[, 3] + extend
@@ -32,67 +32,67 @@ function (fileName, path = NULL, extend, shift, chr.select = NULL,
                 sel = GRanges(chr.select, IRanges(1, 536870912))
             }
             else {
-                cat("Reading bam alignment", fileName, "\n considering ", 
+                message("Reading bam alignment", fileName, "\n considering ",
                   chr.select, " using bam index\n")
                 sel = GRanges(chr.select, IRanges(1, 536870912))
             }
-            scanParam = ScanBamParam(flag = scanFlag, simpleCigar= simpleCigar, what = c("rname", 
+            scanParam = ScanBamParam(flag = scanFlag, simpleCigar= simpleCigar, what = c("rname",
                 "pos", "strand", "qwidth", "isize", "mpos"), which = sel)
         }
         else {
-            cat("Reading bam alignment", fileName, "\n")
-            scanParam = ScanBamParam(flag = scanFlag, simpleCigar= simpleCigar, what = c("rname", 
+            message("Reading bam alignment", fileName, "\n")
+            scanParam = ScanBamParam(flag = scanFlag, simpleCigar= simpleCigar, what = c("rname",
                 "pos", "strand", "qwidth", "isize", "mpos"))
         }
-        regions = scanBam(file = paste(path, fileName, sep = "/"), 
+        regions = scanBam(file = paste(path, fileName, sep = "/"),
             param = scanParam)
-        regions = do.call(rbind, lapply(regions, as.data.frame, 
+        regions = do.call(rbind, lapply(regions, as.data.frame,
             stringsAsFactors = F))
-        regions = data.frame(chr = as.character(as.vector(regions$rname)), 
-            start = as.numeric(as.vector(regions$pos)), stop = as.numeric(as.vector(regions$pos) + 
-                as.vector(regions$qwidth) - 1), strand = as.character(as.vector(regions$strand)), 
+        regions = data.frame(chr = as.character(as.vector(regions$rname)),
+            start = as.numeric(as.vector(regions$pos)), stop = as.numeric(as.vector(regions$pos) +
+                as.vector(regions$qwidth) - 1), strand = as.character(as.vector(regions$strand)),
             stringsAsFactors = F)
     }
     else {
-        cat("Reading bed alignment", fileName, "\n")
-        regions = read.table(paste(path, fileName, sep = "/"), 
-            sep = "\t", header = FALSE, row.names = NULL, comment.char = "", 
-            colClasses = c("character", "numeric", "numeric", 
+        message("Reading bed alignment", fileName, "\n")
+        regions = read.table(paste(path, fileName, sep = "/"),
+            sep = "\t", header = FALSE, row.names = NULL, comment.char = "",
+            colClasses = c("character", "numeric", "numeric",
                 "NULL", "NULL", "character"))
         names(regions) = c("chr", "start", "stop", "strand")
     }
     if (!is.null(chr.select) & !bamindex) {
-        cat("Selecting ", chr.select, "\n")
-        regions = regions[regions[, 1] %in% as.vector(chr.select), 
+        message("Selecting ", chr.select, "\n")
+        regions = regions[regions[, 1] %in% as.vector(chr.select),
             ]
     }
-    cat("Total number of imported short reads: ", nrow(regions), 
+    message("Total number of imported short reads: ", nrow(regions),
         "\n", sep = "")
     regions = adjustReads(regions, extend, shift)
-    cat("Creating GRange Object...\n")
-    regions_GRange = GRanges(seqnames = regions$chr, ranges = IRanges(start = regions$start, 
+    message("Creating GRange Object...\n")
+    regions_GRange = GRanges(seqnames = regions$chr, ranges = IRanges(start = regions$start,
         end = regions$stop), strand = regions$strand)
-   
+
     if(is.logical(uniq)){stop("Parameter 'uniq' is not logical anymore, please specify a p-value and see the MEDIPS vignette.")}
     if (uniq == 1) {
-		cat("Keep at most one 1 read mapping to the same genomic location.\n", sep = "")
+		message("Keep at most one 1 read mapping to the same genomic location.\n", sep = "")
 		regions_GRange = unique(regions_GRange)
-		cat("Number of remaining reads: ", length(regions_GRange), 
+		message("Number of remaining reads: ", length(regions_GRange),
 			"\n", sep = "")
 	} else if (uniq < 1 & uniq > 0) {
-		max_dup_number = qpois(1 - as.numeric(uniq), length(regions_GRange) / 
+		max_dup_number = qpois(1 - as.numeric(uniq), length(regions_GRange) /
 			sum(as.numeric(seqlengths(dataset)[chr.select])))
 		max_dup_number = max(1, max_dup_number)
-		cat("Keep at most ", max_dup_number, 
+		message("Keep at most ", max_dup_number,
 			" read(s) mapping to the same genomic location\n", sep = "")
 		uniq_regions = unique(regions_GRange)
 		dup_number = countMatches(uniq_regions, regions_GRange)
 		dup_number[dup_number > max_dup_number] = max_dup_number
 		regions_GRange = rep(uniq_regions, times = dup_number)
-		cat("Number of remaining reads: ", length(regions_GRange), 
+		message("Number of remaining reads: ", length(regions_GRange),
 			"\n", sep = "")
 	} else if (uniq == 0) {
-		cat("Do not correct for potential PCR artefacts (keep all reads).\n", sep = "")
+		message("Do not correct for potential PCR artefacts (keep all reads).\n", sep = "")
 	} else {
 		stop("Must specify a valid value for parameter uniq. Please check MEDIPS vignette.")
 	}
@@ -101,20 +101,20 @@ function (fileName, path = NULL, extend, shift, chr.select = NULL,
 }
 
 getPairedGRange <-
-function (fileName, path = NULL, extend, shift, chr.select = NULL, 
-    dataset = NULL, uniq = 1e-3, ROI = NULL, isSecondaryAlignment = FALSE, simpleCigar=TRUE) 
+function (fileName, path = NULL, extend, shift, chr.select = NULL,
+    dataset = NULL, uniq = 1e-3, ROI = NULL, isSecondaryAlignment = FALSE, simpleCigar=TRUE)
 {
     ext = substr(fileName, nchar(fileName) - 3, nchar(fileName))
     bam = (ext == ".bam" | ext == ".BAM")
-    bamindex = bam & file.exists(paste(path, "/", fileName, ".bai", 
+    bamindex = bam & file.exists(paste(path, "/", fileName, ".bai",
         sep = ""))
     if (bam) {
-        scanFlag = scanBamFlag(isPaired = T, isProperPair = TRUE, 
-            hasUnmappedMate = FALSE, isUnmappedQuery = F, isFirstMateRead = T, 
+        scanFlag = scanBamFlag(isPaired = T, isProperPair = TRUE,
+            hasUnmappedMate = FALSE, isUnmappedQuery = F, isFirstMateRead = T,
             isSecondMateRead = F, isSecondaryAlignment = isSecondaryAlignment)
         if (bamindex & (!is.null(chr.select) | !is.null(ROI))) {
             if (!is.null(ROI)) {
-                cat("Reading bam alignment", fileName, "\n considering ROIs using bam index\n")
+                message("Reading bam alignment", fileName, "\n considering ROIs using bam index\n")
                 if (!is.null(extend)) {
                   ROI[, 2] = ROI[, 2] - extend
                   ROI[, 3] = ROI[, 3] + extend
@@ -123,88 +123,88 @@ function (fileName, path = NULL, extend, shift, chr.select = NULL,
                   ROI[, 2] = ROI[, 2] - shift
                   ROI[, 3] = ROI[, 3] - shift
                 }
-                sel = GRanges(ROI[, 1], IRanges(start = ROI[, 
+                sel = GRanges(ROI[, 1], IRanges(start = ROI[,
                   2], end = ROI[, 3]))
             }
             else {
-                cat("Reading bam alignment", fileName, "\n considering ", 
+                message("Reading bam alignment", fileName, "\n considering ",
                   chr.select, " using bam index\n")
                 sel = GRanges(chr.select, IRanges(1, 536870912))
             }
-        scanParam = ScanBamParam(flag = scanFlag, simpleCigar= simpleCigar, what = c("rname", 
-		    "pos", "strand", "qwidth", "isize", "mpos"), which = sel)    
+        scanParam = ScanBamParam(flag = scanFlag, simpleCigar= simpleCigar, what = c("rname",
+		    "pos", "strand", "qwidth", "isize", "mpos"), which = sel)
         }
         else {
-            cat("Reading bam alignment", fileName, "\n")
-            scanParam = ScanBamParam(flag = scanFlag, simpleCigar = simpleCigar, what = c("rname", 
+            message("Reading bam alignment", fileName, "\n")
+            scanParam = ScanBamParam(flag = scanFlag, simpleCigar = simpleCigar, what = c("rname",
                   "pos", "strand", "qwidth", "isize", "mpos"))
         }
-   
-        regions = scanBam(file = paste(path, fileName, sep = "/"), 
+
+        regions = scanBam(file = paste(path, fileName, sep = "/"),
             param = scanParam)
-        regions = do.call(rbind, lapply(regions, as.data.frame, 
+        regions = do.call(rbind, lapply(regions, as.data.frame,
             stringsAsFactors = F))
     }
     else {
         stop("BED files in paired end mode not supported.\n")
     }
     if (!is.null(chr.select) & !bamindex) {
-        cat("Selecting", chr.select, "\n")
-        regions = regions[regions[, 1] %in% as.vector(chr.select), 
+        message("Selecting", chr.select, "\n")
+        regions = regions[regions[, 1] %in% as.vector(chr.select),
             ]
     }
-    cat("Total number of imported first mate reads in properly mapped pairs: ", 
+    message("Total number of imported first mate reads in properly mapped pairs: ",
         nrow(regions), "\n", sep = "")
-    cat("scanBamFlag: isPaired = T, isProperPair=TRUE , hasUnmappedMate=FALSE, ", 
-        "isUnmappedQuery = F, isFirstMateRead = T, isSecondMateRead = F\n", 
+    message("scanBamFlag: isPaired = T, isProperPair=TRUE , hasUnmappedMate=FALSE, ",
+        "isUnmappedQuery = F, isFirstMateRead = T, isSecondMateRead = F\n",
         sep = "")
-    cat("Mean insertion size: ", mean(abs(regions$isize)), " nt\n", 
+    message("Mean insertion size: ", mean(abs(regions$isize)), " nt\n",
         sep = "")
-    cat("SD of the insertion size: ", sd(abs(regions$isize)), 
+    message("SD of the insertion size: ", sd(abs(regions$isize)),
         " nt\n", sep = "")
-    cat("Max insertion size: ", max(abs(regions$isize)), " nt\n", 
+    message("Max insertion size: ", max(abs(regions$isize)), " nt\n",
         sep = "")
-    cat("Min insertion size: ", min(abs(regions$isize)), " nt\n", 
+    message("Min insertion size: ", min(abs(regions$isize)), " nt\n",
         sep = "")
-   
+
    qwidth = regions[, "qwidth"]
-   regions = data.frame(chr = as.character(as.vector(regions$rname)), 
-   start = as.numeric(as.vector(regions$pos)), stop = as.numeric(as.vector(regions$mpos)), 
-   strand = as.character(as.vector(regions$strand)), 
+   regions = data.frame(chr = as.character(as.vector(regions$rname)),
+   start = as.numeric(as.vector(regions$pos)), stop = as.numeric(as.vector(regions$mpos)),
+   strand = as.character(as.vector(regions$strand)),
    isize = as.numeric(as.vector(regions$isize)), stringsAsFactors = F)
-   
+
    regionsToRev = regions$start > regions$stop
    regions[regionsToRev, ]$start = regions[regionsToRev,]$stop
-   regions[, "stop"] = regions[, "start"] + abs(regions[, "isize"]) - 1    
-   
-   if(extend!=0){cat("The extend parameter will be neglected, because the actual DNA fragment length is known in paired-end data.\n")}
-   if(shift!=0){cat("The shift parameter will be neglected, because the actual DNA fragment position is known in paired-end data.\n")}
-    
-    cat("Creating GRange Object...\n")
-    regions_GRange = GRanges(seqnames = regions$chr, ranges = IRanges(start = regions$start, 
+   regions[, "stop"] = regions[, "start"] + abs(regions[, "isize"]) - 1
+
+   if(extend!=0){warning("The extend parameter will be neglected, because the actual DNA fragment length is known in paired-end data.\n")}
+   if(shift!=0){warning("The shift parameter will be neglected, because the actual DNA fragment position is known in paired-end data.\n")}
+
+    message("Creating GRange Object...\n")
+    regions_GRange = GRanges(seqnames = regions$chr, ranges = IRanges(start = regions$start,
         end = regions$stop), strand = regions$strand)
-	
+
 	if(is.logical(uniq)){stop("Parameter 'uniq' is not logical anymore, please specify a p-value and see the MEDIPS vignette.")}
-	
+
 	if (uniq == 1) {
-		cat("Keep at most 1 read mapping to the same genomic location.\n", sep = "")
+		message("Keep at most 1 read mapping to the same genomic location.\n", sep = "")
 		regions_GRange = unique(regions_GRange)
-		cat("Number of remaining short reads: ", length(regions_GRange), 
+		message("Number of remaining short reads: ", length(regions_GRange),
 			"\n", sep = "")
 	} else if (uniq < 1 & uniq > 0) {
-		max_dup_number = qpois(1 - as.numeric(uniq), length(regions_GRange) / 
+		max_dup_number = qpois(1 - as.numeric(uniq), length(regions_GRange) /
 			sum(as.numeric(seqlengths(dataset)[chr.select])))
 		max_dup_number = max(1, max_dup_number)
-		cat("Keep at most ", max_dup_number, 
-			" first mate read(s) mapping to the same genomic location\n", sep = "")		
+		message("Keep at most ", max_dup_number,
+			" first mate read(s) mapping to the same genomic location\n", sep = "")
 		uniq_regions = unique(regions_GRange)
 		dup_number = countMatches(uniq_regions, regions_GRange)
 		dup_number[dup_number > max_dup_number] = max_dup_number
 		regions_GRange = rep(uniq_regions, times = dup_number)
-		cat("Number of remaining short reads: ", length(regions_GRange), 
+		message("Number of remaining short reads: ", length(regions_GRange),
 			"\n", sep = "")
 	} else if (uniq == 0) {
-		cat("Do not correct for potential PCR artefacts (keep all reads).\n", sep = "")
+		message("Do not correct for potential PCR artefacts (keep all reads).\n", sep = "")
 	} else {
 		stop("Must specify a valid value for parameter uniq. Please check MEDIPS vignette.")
 	}
@@ -231,17 +231,17 @@ scanBamToGRanges <- function(...) {
 ##Modified:	29/10/2012
 ##Author:	Matthias Lienhard
 getMObjectFromWIG <- function(fileName, path, chr.select=NULL,BSgenome){
-        cat("Reading wiggle file",fileName,"\n")	
+        message("Reading wiggle file",fileName,"\n")
 	if(!is.null(chr.select)){
-          cat("Select chromosomes",chr.select,"\n")
+          message("Select chromosomes",chr.select,"\n")
           sel=GRanges(chr.select,IRanges(1, 536870912))
 	  #this function will warn, if type is not bigwig
-	  wiggle=rtracklayer::import(paste(path,fileName,sep="/"), which=sel)	
+	  wiggle=rtracklayer::import(paste(path,fileName,sep="/"), which=sel)
 	}else{
 	  wiggle=rtracklayer::import(paste(path,fileName,sep="/"))
 	  chr.select=names(seqlengths(wiggle))
 	}
-	
+
 	dataset=get(ls(paste("package:", BSgenome, sep="")))
 	chr_lengths=as.numeric(seqlengths(dataset)[chr.select])
 	genome_count=values(wiggle)[,1]
@@ -256,7 +256,7 @@ getMObjectFromWIG <- function(fileName, path, chr.select=NULL,BSgenome){
 	if(any(wiggle_chrL[m] != ceiling(chr_lengths/window_size))){
 	    stop("ERROR: wiggle file must completly cover all selected chromosomes\nNot covered chr: ",paste(wiggle_chrL[m] != ceiling(chr_lengths/window_size),sep=", "),"\n")
 	}
-	
+
 	#check that values are integer
 	tol = .Machine$double.eps^0.5
 	if(any(abs(genome_count - round(genome_count))>tol)){
@@ -264,13 +264,13 @@ getMObjectFromWIG <- function(fileName, path, chr.select=NULL,BSgenome){
 	}
 	return(new('MEDIPSset', sample_name=fileName,
 				                        path_name=path,
-				                        genome_name=BSgenome, 
+				                        genome_name=BSgenome,
 							number_regions=sum(genome_count),
-							chr_names=chr.select, 
+							chr_names=chr.select,
 							chr_lengths=chr_lengths,
-							genome_count=genome_count, 
+							genome_count=genome_count,
 							extend=0,
-							shifted=0, 
+							shifted=0,
 							window_size=window_size,
 							uniq=NA))
 }
@@ -313,19 +313,19 @@ setTypes<-function(types){
 ##Modified:	12/10/2011
 ##Author:	Lukas Chavez, Joern Dietrich
 adjustReads<-function(regions, extend, shift){
-	if(extend!=0){		
-		cat("Extending reads...\n")
+	if(extend!=0){
+		message("Extending reads...\n")
 		extend.c = pmax(0,extend-regions$stop+regions$start)
 		regions$stop[regions$strand=="+"]=regions$stop[regions$strand=="+"]+extend.c[regions$strand=="+"]
-		regions$start[regions$strand=="-"]=regions$start[regions$strand=="-"]-extend.c[regions$strand=="-"]	
+		regions$start[regions$strand=="-"]=regions$start[regions$strand=="-"]-extend.c[regions$strand=="-"]
 	}
-	
+
 	if(shift!=0){
-		cat("Shifting reads...\n")
+		message("Shifting reads...\n")
 		regions$start[regions$strand=="+"] = regions$start[regions$strand=="+"]+shift
 		regions$stop[regions$strand=="+"] = regions$stop[regions$strand=="+"]+shift
 		regions$start[regions$strand=="-"] = regions$start[regions$strand=="-"]-shift
-		regions$stop[regions$strand=="-"] = regions$stop[regions$strand=="-"]-shift	
+		regions$stop[regions$strand=="-"] = regions$stop[regions$strand=="-"]-shift
 	}
 	return(regions)
 }

--- a/R/MEDIPS.rms.R
+++ b/R/MEDIPS.rms.R
@@ -20,7 +20,7 @@ MEDIPS.rms <- function(MSet=NULL, CSet=NULL, ccObj=NULL){
 
 	##Weight signals by linear regression obtained parameters
 	####################
-	message("Calculating relative methylation score...\n")
+	message("Calculating relative methylation score...", appendLF=T)
 
         estim=numeric(length(ccObj$mean_signal))
 

--- a/R/MEDIPS.rms.R
+++ b/R/MEDIPS.rms.R
@@ -8,10 +8,10 @@
 ##Author:	Lukas Chavez
 
 MEDIPS.rms <- function(MSet=NULL, CSet=NULL, ccObj=NULL){
-	
+
 	signal = genome_count(MSet)
 	coupling = genome_CF(CSet)
-		
+
 	if(is.null(ccObj)){
 		##Calculate calibration curve
 		#####################################
@@ -20,8 +20,8 @@ MEDIPS.rms <- function(MSet=NULL, CSet=NULL, ccObj=NULL){
 
 	##Weight signals by linear regression obtained parameters
 	####################
-	cat("Calculating relative methylation score...\n")
-	
+	message("Calculating relative methylation score...\n")
+
         estim=numeric(length(ccObj$mean_signal))
 
 	##For the low range of the calibration curve (< max_index) divide counts by observed mean count
@@ -31,7 +31,7 @@ MEDIPS.rms <- function(MSet=NULL, CSet=NULL, ccObj=NULL){
 	##For the higher range of the calibration curve (>=max_index) divide counts by estimated count
 	high_range=(ccObj$max_index+1):length(estim)
 
-	estim[high_range]=ccObj$intercept + (ccObj$slope * ccObj$coupling_level[high_range]) 
+	estim[high_range]=ccObj$intercept + (ccObj$slope * ccObj$coupling_level[high_range])
 
 	#rms normalization:
 	signal=signal/estim[coupling+1]
@@ -50,12 +50,12 @@ MEDIPS.rms <- function(MSet=NULL, CSet=NULL, ccObj=NULL){
 	signal = log2(signal)
 
 	signal[is.na(signal)] = 0
-				
+
 	##Shift signals into positive value range
 	####################
 	minsignal=min(signal[signal!=-Inf])
 	signal[signal!=-Inf]=signal[signal!=-Inf]+abs(minsignal)
-	
+
 	##Transform values into the interval [0:1] by compressing the top 20% of the signals
 	####################
 	maxsignal = max(signal[signal!=Inf])*0.8

--- a/R/MEDIPS.saturation.R
+++ b/R/MEDIPS.saturation.R
@@ -1,5 +1,5 @@
 ##########################################################################
-##Estimates the reproducibility of genome wide short read coverages 
+##Estimates the reproducibility of genome wide short read coverages
 ##by sampling subsets of the given data and comparing accordance.
 ##########################################################################
 ##Input:	bam file or tab (|) separated txt file "chr | start | stop  | strand"
@@ -12,17 +12,17 @@
 
 MEDIPS.saturation<-
 function(file=NULL, BSgenome=NULL, nit=10, nrit=1, empty_bins=TRUE, rank=FALSE, extend=0, shift=0,  window_size=500, uniq=1e-3, chr.select=NULL, paired=F, isSecondaryAlignment = FALSE, simpleCigar=TRUE){
-	
+
 	## Proof of correctness....
 	if(is.null(BSgenome)){stop("Must specify a BSgenome library.")}
 	if(is.null(file)){stop("Must specify a bam or txt file.")}
-		
-	## Read file		
+
+	## Read file
 	fileName=unlist(strsplit(file, "/"))[length(unlist(strsplit(file, "/")))]
-	path=paste(unlist(strsplit(file, "/"))[1:(length(unlist(strsplit(file, "/"))))-1], collapse="/") 
-	if(path==""){path=getwd()}		
+	path=paste(unlist(strsplit(file, "/"))[1:(length(unlist(strsplit(file, "/"))))-1], collapse="/")
+	if(path==""){path=getwd()}
 	if(!fileName%in%dir(path)){stop(paste("File", fileName, " not found in", path, sep =" "))}
-	
+
 	dataset=get(ls(paste("package:", BSgenome, sep="")))
 	if(!paired){GRange.Reads = getGRange(fileName, path, extend, shift, chr.select, dataset, uniq, ROI = NULL, isSecondaryAlignment = isSecondaryAlignment, simpleCigar=simpleCigar)}
 	else{GRange.Reads = getPairedGRange(fileName, path, extend, shift, chr.select, dataset, uniq, ROI = NULL, isSecondaryAlignment = isSecondaryAlignment, simpleCigar=simpleCigar)}
@@ -30,88 +30,88 @@ function(file=NULL, BSgenome=NULL, nit=10, nrit=1, empty_bins=TRUE, rank=FALSE, 
 	## Sort chromosomes
 	if(length(unique(seqlevels(GRange.Reads)))>1){chromosomes=mixedsort(unique(seqlevels(GRange.Reads)))}
 	if(length(unique(seqlevels(GRange.Reads)))==1){chromosomes=unique(seqlevels(GRange.Reads))}
-	
+
 	## Get chromosome lengths for all chromosomes within data set.
-	cat(paste("Loading chromosome lengths for ",BSgenome, "...\n", sep=""))		
+	message(paste("Loading chromosome lengths for ",BSgenome, "...\n", sep=""))
 	#chr_lengths=as.numeric(sapply(chromosomes, function(x){as.numeric(length(dataset[[x]]))}))
-	chr_lengths=as.numeric(seqlengths(dataset)[chromosomes])	
-	
-	## Create the genome vector Granges object	
+	chr_lengths=as.numeric(seqlengths(dataset)[chromosomes])
+
+	## Create the genome vector Granges object
 	no_chr_windows = ceiling(chr_lengths/window_size)
-	supersize_chr = cumsum(no_chr_windows)	
-	Granges.genomeVec = MEDIPS.GenomicCoordinates(supersize_chr, no_chr_windows, chromosomes, chr_lengths, window_size)	
-				
+	supersize_chr = cumsum(no_chr_windows)
+	Granges.genomeVec = MEDIPS.GenomicCoordinates(supersize_chr, no_chr_windows, chromosomes, chr_lengths, window_size)
+
 	####################################
 	#The first run (a1) is to calculate the saturation based on two distinct subsets of given regions.
 	#The second run (a2) is to estimate a saturation based on an artifically doubled set of given regions.
 	####################################
-	for(a in 1:2){		
+	for(a in 1:2){
 		if(a==1){
 			distinctSets_size=floor(length(GRange.Reads)/2)
 			subset_size=floor(distinctSets_size/nit)
-			cat("Saturation analysis...\n")
-		}		
+			message("Saturation analysis...\n")
+		}
 		if(a==2){
-			cat("Estimated saturation analysis...\n")
+			message("Estimated saturation analysis...\n")
 			distinctSets_size=length(GRange.Reads)
-			GRange.Reads = c(GRange.Reads, GRange.Reads)			
+			GRange.Reads = c(GRange.Reads, GRange.Reads)
 			nit=nit*2
-		}			
-						
+		}
+
 		####################################
 		#The loops: First one is  for repeating the random process and results are averaged at the end.
 		####################################
-		for(r in 1:nrit){			
-			cat(paste("Random iteration: ",r,"/", nrit, "...\n", sep=""))
-						
+		for(r in 1:nrit){
+			message(paste("Random iteration: ",r,"/", nrit, "...\n", sep=""))
+
 			correlation=0
 			no_considered_reads=0
-	
+
 			##Create a random order for all given regions.
-			random=sample(1:length(GRange.Reads), length(GRange.Reads))		
-			
+			random=sample(1:length(GRange.Reads), length(GRange.Reads))
+
 			####################################
 			#The loops: Second one is  for calculating correlations for subsets of the current total set of given regions.
 			####################################
-			for(l in 1:nit){						
-				cat(paste("Processing subset ", l, "/", nit, "...\n", sep=""))
-				
-				subset_start_one=(l-1)*subset_size+1			
+			for(l in 1:nit){
+				message(paste("Processing subset ", l, "/", nit, "...\n", sep=""))
+
+				subset_start_one=(l-1)*subset_size+1
 				subset_start_two=((l-1)*subset_size+1)+distinctSets_size
-				
-				if(l<nit){	
+
+				if(l<nit){
 					subset_stop_one=l*subset_size
-					subset_stop_two=(l*subset_size)+distinctSets_size												
+					subset_stop_two=(l*subset_size)+distinctSets_size
 					no_considered_reads=c(no_considered_reads, l*subset_size)
 				}
-				if(l==nit){	
-					subset_stop_one=distinctSets_size							
-					subset_stop_two=length(GRange.Reads)					
+				if(l==nit){
+					subset_stop_one=distinctSets_size
+					subset_stop_two=length(GRange.Reads)
 					no_considered_reads=c(no_considered_reads, distinctSets_size)
-				}		
-				
-				##Calculate coverage							
+				}
+
+				##Calculate coverage
 				if(l==1){
-					genome_value_a = countOverlaps(Granges.genomeVec, GRange.Reads[c(random[subset_start_one:subset_stop_one])]) 
-					genome_value_b = countOverlaps(Granges.genomeVec, GRange.Reads[c(random[subset_start_two:subset_stop_two])]) 
+					genome_value_a = countOverlaps(Granges.genomeVec, GRange.Reads[c(random[subset_start_one:subset_stop_one])])
+					genome_value_b = countOverlaps(Granges.genomeVec, GRange.Reads[c(random[subset_start_two:subset_stop_two])])
 				}
 				else{
-					genome_value_a = genome_value_a + countOverlaps(Granges.genomeVec, GRange.Reads[c(random[subset_start_one:subset_stop_one])]) 
-					genome_value_b = genome_value_b + countOverlaps(Granges.genomeVec, GRange.Reads[c(random[subset_start_two:subset_stop_two])]) 
-				}				
-								
-				##Calculate correlation for each interval							
+					genome_value_a = genome_value_a + countOverlaps(Granges.genomeVec, GRange.Reads[c(random[subset_start_one:subset_stop_one])])
+					genome_value_b = genome_value_b + countOverlaps(Granges.genomeVec, GRange.Reads[c(random[subset_start_two:subset_stop_two])])
+				}
+
+				##Calculate correlation for each interval
 				if(empty_bins){
 					if(!rank){correlation=c(correlation, cor(genome_value_a, genome_value_b))}
 					if(rank){correlation=c(correlation, cor(rank(genome_value_a), rank(genome_value_b)))}
-					
+
 				}
 				if(!empty_bins){
 					if(!rank){correlation=c(correlation, cor(genome_value_a[genome_value_a!=0 & genome_value_b!=0], genome_value_b[genome_value_a!=0 & genome_value_b!=0]))}
 					if(rank){correlation=c(correlation, cor(rank(genome_value_a[genome_value_a!=0 & genome_value_b!=0]), rank(genome_value_b[genome_value_a!=0 & genome_value_b!=0])))}
 				}
-			}			
-	
+			}
+
 			##Store the results of each iteration step.
 			if(r==1){
 				output_matrix=matrix(ncol=2, nrow=length(correlation))
@@ -120,13 +120,13 @@ function(file=NULL, BSgenome=NULL, nit=10, nrit=1, empty_bins=TRUE, rank=FALSE, 
 			}
 			if(r>1){
 				output_matrix[,2]=output_matrix[,2]+correlation
-			}					
-		
+			}
+
 		}
 
 		##Correct for the number of Monte-Carlo iterations
 		output_matrix[,2]=output_matrix[,2]/nrit
-		
+
 		if(a==1){
 			distinct=output_matrix
 			maxTruCor=c(output_matrix[length(correlation),1], output_matrix[length(correlation),2])
@@ -136,6 +136,6 @@ function(file=NULL, BSgenome=NULL, nit=10, nrit=1, empty_bins=TRUE, rank=FALSE, 
 			saturationObj=list(distinctSets=distinct, estimation=output_matrix, numberReads=(length(GRange.Reads)/2), maxEstCor=maxEstCor, maxTruCor=maxTruCor)
 		}
 	}
-	gc()				
+	gc()
 	return(saturationObj)
 }

--- a/R/MEDIPS.saturation.R
+++ b/R/MEDIPS.saturation.R
@@ -32,7 +32,7 @@ function(file=NULL, BSgenome=NULL, nit=10, nrit=1, empty_bins=TRUE, rank=FALSE, 
 	if(length(unique(seqlevels(GRange.Reads)))==1){chromosomes=unique(seqlevels(GRange.Reads))}
 
 	## Get chromosome lengths for all chromosomes within data set.
-	message(paste("Loading chromosome lengths for ",BSgenome, "...\n", sep=""))
+	message("Loading chromosome lengths for ", BSgenome, "...", appendLF=T)
 	#chr_lengths=as.numeric(sapply(chromosomes, function(x){as.numeric(length(dataset[[x]]))}))
 	chr_lengths=as.numeric(seqlengths(dataset)[chromosomes])
 
@@ -49,10 +49,10 @@ function(file=NULL, BSgenome=NULL, nit=10, nrit=1, empty_bins=TRUE, rank=FALSE, 
 		if(a==1){
 			distinctSets_size=floor(length(GRange.Reads)/2)
 			subset_size=floor(distinctSets_size/nit)
-			message("Saturation analysis...\n")
+			message("Saturation analysis...", appendLF=T)
 		}
 		if(a==2){
-			message("Estimated saturation analysis...\n")
+			message("Estimated saturation analysis...", appendLF=T)
 			distinctSets_size=length(GRange.Reads)
 			GRange.Reads = c(GRange.Reads, GRange.Reads)
 			nit=nit*2
@@ -62,7 +62,7 @@ function(file=NULL, BSgenome=NULL, nit=10, nrit=1, empty_bins=TRUE, rank=FALSE, 
 		#The loops: First one is  for repeating the random process and results are averaged at the end.
 		####################################
 		for(r in 1:nrit){
-			message(paste("Random iteration: ",r,"/", nrit, "...\n", sep=""))
+			message("Random iteration: ", r, "/", nrit, "...", appendLF=T)
 
 			correlation=0
 			no_considered_reads=0
@@ -74,7 +74,7 @@ function(file=NULL, BSgenome=NULL, nit=10, nrit=1, empty_bins=TRUE, rank=FALSE, 
 			#The loops: Second one is  for calculating correlations for subsets of the current total set of given regions.
 			####################################
 			for(l in 1:nit){
-				message(paste("Processing subset ", l, "/", nit, "...\n", sep=""))
+				message("Processing subset ", l, "/", nit, "...", appendLF=T)
 
 				subset_start_one=(l-1)*subset_size+1
 				subset_start_two=((l-1)*subset_size+1)+distinctSets_size

--- a/R/MEDIPS.selectSig.R
+++ b/R/MEDIPS.selectSig.R
@@ -3,15 +3,15 @@
 ## w.r.t. to specified parameters
 ##########################################################################
 ##Input:	result table returned by MEDIPS.meth (or by MEDIPS.selectROIs)
-##Param:	
+##Param:
 ##Output:	row-wise subset of input
 ##Modified:	11/28/2011
 ##Author:	Lukas Chavez
 
 MEDIPS.selectSig = function(results=NULL, p.value=0.01, adj=T, ratio=NULL, bg.counts=NULL, CNV=F){
-	
-	if(is.null(results)){stop("Must specify a result table.")}		
-	cat(paste("Total number of windows: ", nrow(results), "\n", sep=""))		
+
+	if(is.null(results)){stop("Must specify a result table.")}
+	 message(paste("Total number of windows: ", nrow(results), "\n", sep=""))
 
 	##Background counts- preparation
         ################################
@@ -29,41 +29,41 @@ MEDIPS.selectSig = function(results=NULL, p.value=0.01, adj=T, ratio=NULL, bg.co
         }
 
 	##Filter for windows tested for differential  methylation
-	##########################################################	
+	##########################################################
 	results=results[!is.na(results[,grep("p.value", colnames(results))[1]]),]
-	cat(paste("Number of windows tested for differential methylation: ", nrow(results), "\n", sep=""))
-	
-	
+	message(paste("Number of windows tested for differential methylation: ", nrow(results), "\n", sep=""))
+
+
 	#Filter for p.values
 	#######################
 	if(adj){value_pvalue = grep("adj.p.value", colnames(results))}
-	else{value_pvalue = grep("p.value", colnames(results))[1]} 
-		
+	else{value_pvalue = grep("p.value", colnames(results))[1]}
+
 	results=results[results[,value_pvalue]<=p.value,]
-	
-	if(adj){cat(paste("Remaining number of windows with adjusted p.value<=", p.value, ": ", nrow(results), "\n", sep=""))}
-	else{cat(paste("Remaining number of windows with p.value<=", p.value, ": ", nrow(results), "\n", sep=""))}
+
+	if(adj){message(paste("Remaining number of windows with adjusted p.value<=", p.value, ": ", nrow(results), "\n", sep=""))}
+	else{message(paste("Remaining number of windows with p.value<=", p.value, ": ", nrow(results), "\n", sep=""))}
 
 	##Ratio and CNV specific filter
 	##############################
 	##Filter for ratio
 	if(!is.null(ratio)& CNV==F){
-		
+
 		column_ratio = grep("score.log2.ratio", colnames(results))
 		if(length(column_ratio)==0){
 			column_ratio = grep("edgeR.logFC", colnames(results))
 		}
 
 		results=results[results[,column_ratio]>=log2(ratio) | results[,column_ratio]<=(log2(1/ratio)),]
-		cat(paste("Remaining number of windows with ratio >=",ratio," (or <=", round(1/ratio, digits=2), ", respectively): ", nrow(results), "\n", sep=""))		
-	}	
+		message(paste("Remaining number of windows with ratio >=",ratio," (or <=", round(1/ratio, digits=2), ", respectively): ", nrow(results), "\n", sep=""))
+	}
 	if(!is.null(ratio) & CNV==T){
-		
+
 		column_ratio = grep("score.log2.ratio", colnames(results))
                 if(length(column_ratio)==0){
-                        column_ratio = grep("edgeR.logFC", colnames(results))   
+                        column_ratio = grep("edgeR.logFC", colnames(results))
                	}
-		
+
 		column_CNVratio = grep("CNV.log2.ratio", colnames(results))
 		if(length(column_CNVratio)==0){
 			stop("No CNV results available.")
@@ -73,21 +73,19 @@ MEDIPS.selectSig = function(results=NULL, p.value=0.01, adj=T, ratio=NULL, bg.co
 		}
 		results[is.na(results[,column_CNVratio]),column_CNVratio]=0
 		results=results[abs(results[,column_ratio]-results[,column_CNVratio])>=abs(log2(ratio)),]
-		cat(paste("Remaining number of windows with CNV corrected ratio >=",ratio," (or <=", round(1/ratio, digits=2), ", respectively): ", nrow(results), "\n", sep=""))
+		message(paste("Remaining number of windows with CNV corrected ratio >=",ratio," (or <=", round(1/ratio, digits=2), ", respectively): ", nrow(results), "\n", sep=""))
 	}
 	if(CNV==T & is.null(ratio)){
 		stop("Please specify a ratio when setting CNV=T.")
 	}
 
-	##Background counts 
+	##Background counts
         ########################################
         if(!is.null(bg.counts)){
                 results=results[results$MSets1.counts.mean>=bg.t | results$MSets2.counts.mean>=bg.t,]
-                cat(paste("Remaining number of windows where the mean count of at least one group is >=", round(bg.t, digits=2), ": ", nrow(results),"\n", sep=""))
+                message(paste("Remaining number of windows where the mean count of at least one group is >=", round(bg.t, digits=2), ": ", nrow(results),"\n", sep=""))
         }
 
 	gc()
 	return(as.data.frame(results,  stringsAsFactors=F))
 }
-
-

--- a/R/MEDIPS.selectSig.R
+++ b/R/MEDIPS.selectSig.R
@@ -11,7 +11,7 @@
 MEDIPS.selectSig = function(results=NULL, p.value=0.01, adj=T, ratio=NULL, bg.counts=NULL, CNV=F){
 
 	if(is.null(results)){stop("Must specify a result table.")}
-	 message(paste("Total number of windows: ", nrow(results), "\n", sep=""))
+	 message("Total number of windows: ", nrow(results), appendLF=T)
 
 	##Background counts- preparation
         ################################
@@ -31,7 +31,7 @@ MEDIPS.selectSig = function(results=NULL, p.value=0.01, adj=T, ratio=NULL, bg.co
 	##Filter for windows tested for differential  methylation
 	##########################################################
 	results=results[!is.na(results[,grep("p.value", colnames(results))[1]]),]
-	message(paste("Number of windows tested for differential methylation: ", nrow(results), "\n", sep=""))
+	message("Number of windows tested for differential methylation: ", nrow(results), appendLF=T)
 
 
 	#Filter for p.values
@@ -41,8 +41,8 @@ MEDIPS.selectSig = function(results=NULL, p.value=0.01, adj=T, ratio=NULL, bg.co
 
 	results=results[results[,value_pvalue]<=p.value,]
 
-	if(adj){message(paste("Remaining number of windows with adjusted p.value<=", p.value, ": ", nrow(results), "\n", sep=""))}
-	else{message(paste("Remaining number of windows with p.value<=", p.value, ": ", nrow(results), "\n", sep=""))}
+	if(adj){message("Remaining number of windows with adjusted p.value<=", p.value, ": ", nrow(results), appendLF=T)}
+	else{message("Remaining number of windows with p.value<=", p.value, ": ", nrow(results), appendLF=T)}
 
 	##Ratio and CNV specific filter
 	##############################
@@ -55,7 +55,7 @@ MEDIPS.selectSig = function(results=NULL, p.value=0.01, adj=T, ratio=NULL, bg.co
 		}
 
 		results=results[results[,column_ratio]>=log2(ratio) | results[,column_ratio]<=(log2(1/ratio)),]
-		message(paste("Remaining number of windows with ratio >=",ratio," (or <=", round(1/ratio, digits=2), ", respectively): ", nrow(results), "\n", sep=""))
+		message("Remaining number of windows with ratio >=", ratio, " (or <=", round(1/ratio, digits=2), ", respectively): ", nrow(results), appendLF=T)
 	}
 	if(!is.null(ratio) & CNV==T){
 
@@ -73,7 +73,7 @@ MEDIPS.selectSig = function(results=NULL, p.value=0.01, adj=T, ratio=NULL, bg.co
 		}
 		results[is.na(results[,column_CNVratio]),column_CNVratio]=0
 		results=results[abs(results[,column_ratio]-results[,column_CNVratio])>=abs(log2(ratio)),]
-		message(paste("Remaining number of windows with CNV corrected ratio >=",ratio," (or <=", round(1/ratio, digits=2), ", respectively): ", nrow(results), "\n", sep=""))
+		message("Remaining number of windows with CNV corrected ratio >=",ratio," (or <=", round(1/ratio, digits=2), ", respectively): ", nrow(results), appendLF=T)
 	}
 	if(CNV==T & is.null(ratio)){
 		stop("Please specify a ratio when setting CNV=T.")
@@ -83,7 +83,7 @@ MEDIPS.selectSig = function(results=NULL, p.value=0.01, adj=T, ratio=NULL, bg.co
         ########################################
         if(!is.null(bg.counts)){
                 results=results[results$MSets1.counts.mean>=bg.t | results$MSets2.counts.mean>=bg.t,]
-                message(paste("Remaining number of windows where the mean count of at least one group is >=", round(bg.t, digits=2), ": ", nrow(results),"\n", sep=""))
+                message("Remaining number of windows where the mean count of at least one group is >=", round(bg.t, digits=2), ": ", nrow(results), appendLF=T)
         }
 
 	gc()

--- a/R/MEDIPS.seqCoverage.R
+++ b/R/MEDIPS.seqCoverage.R
@@ -3,47 +3,47 @@
 ##########################################################################
 ##Input:	bam file or tab (|) separated txt file "chr | start | stop  | strand"
 ##Param:	file, BSSgenome, file, pattern, extend, shift, uniq (T|F), chr.select
-##Output:	seqCoverage result object 
+##Output:	seqCoverage result object
 ##Requires:	gtools, BSgenome, MEDIPS.getPositions, MEDIPS.Bam2GRanges, MEDIPS.txt2Granges
 ##Modified:	30/11/2015
 ##Author:	Lukas Chavez
 
-MEDIPS.seqCoverage<-                                  
+MEDIPS.seqCoverage<-
 function(file=NULL, BSgenome=NULL, pattern="CG", extend=0, shift=0, uniq=1e-3, chr.select=NULL, paired=F, isSecondaryAlignment = FALSE, simpleCigar=TRUE){
-	
+
 	## Proof of correctness....
 	if(is.null(BSgenome)){stop("Must specify a BSgenome library.")}
 	if(is.null(file)){stop("Must specify a bam or txt file.")}
-		
-	## Read file		
+
+	## Read file
 	fileName=unlist(strsplit(file, "/"))[length(unlist(strsplit(file, "/")))]
-	path=paste(unlist(strsplit(file, "/"))[1:(length(unlist(strsplit(file, "/"))))-1], collapse="/") 
-	if(path==""){path=getwd()}		
+	path=paste(unlist(strsplit(file, "/"))[1:(length(unlist(strsplit(file, "/"))))-1], collapse="/")
+	if(path==""){path=getwd()}
 	if(!fileName%in%dir(path)){stop(paste("File", fileName, " not found in", path, sep =" "))}
-	
+
 	dataset=get(ls(paste("package:", BSgenome, sep="")))
 	if(!paired){GRange.Reads = getGRange(fileName, path, extend, shift, chr.select, dataset, uniq, ROI = NULL, isSecondaryAlignment = isSecondaryAlignment, simpleCigar=simpleCigar)}
 	else{GRange.Reads = getPairedGRange(fileName, path, extend, shift, chr.select, dataset, uniq, ROI = NULL, isSecondaryAlignment = isSecondaryAlignment, simpleCigar=simpleCigar)}
-		
+
 	## Sort chromosomeos
 	if(length(unique(seqlevels(GRange.Reads)))>1){chromosomes=mixedsort(unique(seqlevels(GRange.Reads)))}
 	if(length(unique(seqlevels(GRange.Reads)))==1){chromosomes=unique(seqlevels(GRange.Reads))}
-	
+
 	## Get chromosome lengths for all chromosomes within data set.
-	cat(paste("Loading chromosome lengths for ",BSgenome, "...\n", sep=""))		
+	message(paste("Loading chromosome lengths for ",BSgenome, "...\n", sep=""))
 	#chr_lengths=as.numeric(sapply(chromosomes, function(x){as.numeric(length(dataset[[x]]))}))
-	chr_lengths=as.numeric(seqlengths(dataset)[chromosomes])	
-	
+	chr_lengths=as.numeric(seqlengths(dataset)[chromosomes])
+
 	## Get the genomic positions of the sequence pattern
-	cat("Get genomic sequence pattern positions...\n")
-	GRanges.pattern = MEDIPS.getPositions(BSgenome, pattern, chromosomes)	
-		
-	cat("Calculating sequence pattern coverage...\n")
-	overlap = countOverlaps(GRanges.pattern, GRange.Reads) 
+	message("Get genomic sequence pattern positions...\n")
+	GRanges.pattern = MEDIPS.getPositions(BSgenome, pattern, chromosomes)
+
+	message("Calculating sequence pattern coverage...\n")
+	overlap = countOverlaps(GRanges.pattern, GRange.Reads)
 	overlap_2 = countOverlaps(GRange.Reads, GRanges.pattern)
 	overlap_2 = length(overlap_2[overlap_2==0])
-	
-	
+
+
 	seqCoverageObject=list(cov.res=overlap, pattern=pattern, numberReads=length(GRange.Reads), numberReadsWO=overlap_2)
 	gc()
 	return(seqCoverageObject)

--- a/R/MEDIPS.seqCoverage.R
+++ b/R/MEDIPS.seqCoverage.R
@@ -30,15 +30,15 @@ function(file=NULL, BSgenome=NULL, pattern="CG", extend=0, shift=0, uniq=1e-3, c
 	if(length(unique(seqlevels(GRange.Reads)))==1){chromosomes=unique(seqlevels(GRange.Reads))}
 
 	## Get chromosome lengths for all chromosomes within data set.
-	message(paste("Loading chromosome lengths for ",BSgenome, "...\n", sep=""))
+	message("Loading chromosome lengths for ",BSgenome, "...", appendLF=T)
 	#chr_lengths=as.numeric(sapply(chromosomes, function(x){as.numeric(length(dataset[[x]]))}))
 	chr_lengths=as.numeric(seqlengths(dataset)[chromosomes])
 
 	## Get the genomic positions of the sequence pattern
-	message("Get genomic sequence pattern positions...\n")
+	message("Get genomic sequence pattern positions...", appendLF=T)
 	GRanges.pattern = MEDIPS.getPositions(BSgenome, pattern, chromosomes)
 
-	message("Calculating sequence pattern coverage...\n")
+	message("Calculating sequence pattern coverage...", appendLF=T)
 	overlap = countOverlaps(GRanges.pattern, GRange.Reads)
 	overlap_2 = countOverlaps(GRange.Reads, GRanges.pattern)
 	overlap_2 = length(overlap_2[overlap_2==0])


### PR DESCRIPTION
... "warning()" or "error()", which can be filtered out in knitr, if one needs a "clean" output for a report, especially for genomes with hundreds of "chromosomes", like GRCh38. See https://yihui.name/knitr/options/#text-results and https://stackoverflow.com/questions/36699272/why-is-message-a-better-choice-than-print-in-r-for-writing-a-package for the reason for these changes.

Hi Lukas!
I was using your nice package to process a number of MedIP-Seq samples and generate a report using knitr (from Rstudio). 
I had quite a few samples and I used version hg38 of the human genome, which has a lot of chromosomes (i.e. the "ALT" haplotypes and other types of small contigs - a few hundreds). 
I also tried to show the plots for each sample (e.g. the saturation plot or calibration curve) in a tabset, for clarity. 
Therefore, I had to run these functions in a loop for each sample and dynamically create a label for each tab (e.g. "### sample1"). 
The problem I had was that the output of these functions was very verbose (since it listed all the chromosomes from hg38) and I could not suppress it - because I needed to keep the dynamically created label. 
The easiest solution was to modify your R source and replace all the cat()'s and in a few instances print()
s with either message(), warning() or error(),  depending on context - which basically do the same thing but they can be very easily excluded from output if necessary.
This might be useful for other users with the same requirements. 
Just a note: a lot of the "differences"  in this commit were just tabs or empty space in the end of lines - which were automatically corrected the editor I used - atom. 
Razvan